### PR TITLE
Link to Gist for tunnelling start/stop script

### DIFF
--- a/documentation/getting_started.md
+++ b/documentation/getting_started.md
@@ -194,19 +194,34 @@ Create an AWS virtual machine.
 * Create a spinnaker-tunnel.sh file with the following content, and give it execute permissions
 
           #!/bin/bash
+
           socket=$HOME/.ssh/spinnaker-tunnel.ctl
 
-          if [ ! \( -e ${socket} \) ]; then
-            echo "Opening tunnel to Spinnaker..."
-            ssh -f -N spinnaker-start && echo "Tunnel open."
-          else
-            echo "Closing tunnel to Spinnaker..."
-            ssh -O "exit" spinnaker-stop && echo "Tunnel closed."
+          if [ "$1" == "start" ]; then
+            if [ ! \( -e ${socket} \) ]; then
+              echo "Starting tunnel to Spinnaker..."
+              ssh -f -N spinnaker-start && echo "Done."
+            else
+              echo "Tunnel to Spinnaker running."
+            fi
           fi
 
-* Execute the script to toggle your Spinnaker tunnel
+          if [ "$1" == "stop" ]; then
+            if [ \( -e ${socket} \) ]; then
+              echo "Stopping tunnel to Spinnaker..."
+              ssh -O "exit" spinnaker-stop && echo "Done."
+            else
+              echo "Tunnel to Spinnaker stopped."
+            fi
+          fi
 
-          ./spinnaker-tunnel.sh
+* Execute the script to start your Spinnaker tunnel
+
+          ./spinnaker-tunnel.sh start
+
+* You can also stop your Spinnaker tunnel
+
+          ./spinnaker-tunnel.sh stop
 
 ### Google Cloud Platform Setup
 

--- a/documentation/getting_started.md
+++ b/documentation/getting_started.md
@@ -172,18 +172,41 @@ Create an AWS virtual machine.
 * Note that it will take several minutes for Spinnaker post-configurations to complete.
 
 1. Shell in and open an SSH tunnel from your host to the virtual machine.
-* Add this to ~/.ssh/config (There's also an extended [config and start/stop script Gist](https://gist.github.com/Japh/63b4a53883d68c648e77) available)
+* Add this to ~/.ssh/config
 
-          Host spinnaker
-            HostName <Public IP address of instance you just created>
+          Host spinnaker-start
+            HostName <Public DNS name of instance you just created>
             IdentityFile </path/to/my-aws-account-keypair.pem>
+            ControlMaster yes
+            ControlPath ~/.ssh/spinnaker-tunnel.ctl
+            RequestTTY no
             LocalForward 9000 127.0.0.1:9000
             LocalForward 8084 127.0.0.1:8084
             LocalForward 8087 127.0.0.1:8087
             User ubuntu
-* Execute
 
-          ssh spinnaker
+          Host spinnaker-stop
+            HostName <Public DNS name of instance you just created>
+            IdentityFile </path/to/my-aws-account-keypair.pem>
+            ControlPath ~/.ssh/spinnaker-tunnel.ctl
+            RequestTTY no
+
+* Create a spinnaker-tunnel.sh file with the following content, and give it execute permissions
+
+          #!/bin/bash
+          socket=$HOME/.ssh/spinnaker-tunnel.ctl
+
+          if [ ! \( -e ${socket} \) ]; then
+            echo "Opening tunnel to Spinnaker..."
+            ssh -f -N spinnaker-start && echo "Tunnel open."
+          else
+            echo "Closing tunnel to Spinnaker..."
+            ssh -O "exit" spinnaker-stop && echo "Tunnel closed."
+          fi
+
+* Execute the script to toggle your Spinnaker tunnel
+
+          ./spinnaker-tunnel.sh
 
 ### Google Cloud Platform Setup
 

--- a/documentation/getting_started.md
+++ b/documentation/getting_started.md
@@ -172,7 +172,7 @@ Create an AWS virtual machine.
 * Note that it will take several minutes for Spinnaker post-configurations to complete.
 
 1. Shell in and open an SSH tunnel from your host to the virtual machine.
-* Add this to ~/.ssh/config
+* Add this to ~/.ssh/config (There's also an extended [config and start/stop script Gist](https://gist.github.com/Japh/63b4a53883d68c648e77) available)
 
           Host spinnaker
             HostName <Public IP address of instance you just created>


### PR DESCRIPTION
Wasn't sure whether to add the contents of the Gist to the docs, or just link to it. Linking for now.

The script and config make opening and closing the tunnel to Spinnaker on AWS much more user-friendly. Hopefully others find it useful. @andyfleming appears to have found it useful already, and @tomaslin suggested adding to the docs.