### PR TITLE
favicons typo

### DIFF
--- a/_includes/favicons.html
+++ b/_includes/favicons.html
@@ -7,11 +7,11 @@
 <link rel="apple-touch-icon" sizes="144x144" href="{{ site.baseurl }}/images/favicons/apple-touch-icon-144x144.png">
 <link rel="apple-touch-icon" sizes="152x152" href="{{ site.baseurl }}/images/favicons/apple-touch-icon-152x152.png">
 <link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}/images/favicons/apple-touch-icon-180x180.png">
-<link rel="icon" type="image/png" href="{{ site.baseurl }}/images/favicons/favicons-32x32.png" sizes="32x32">
-<link rel="icon" type="image/png" href="{{ site.baseurl }}/images/favicons/favicons-194x194.png" sizes="194x194">
-<link rel="icon" type="image/png" href="{{ site.baseurl }}/images/favicons/favicons-96x96.png" sizes="96x96">
+<link rel="icon" type="image/png" href="{{ site.baseurl }}/images/favicons/favicon-32x32.png" sizes="32x32">
+<link rel="icon" type="image/png" href="{{ site.baseurl }}/images/favicons/favicon-194x194.png" sizes="194x194">
+<link rel="icon" type="image/png" href="{{ site.baseurl }}/images/favicons/favicon-96x96.png" sizes="96x96">
 <link rel="icon" type="image/png" href="{{ site.baseurl }}/images/favicons/android-chrome-192x192.png" sizes="192x192">
-<link rel="icon" type="image/png" href="{{ site.baseurl }}/images/favicons/favicons-16x16.png" sizes="16x16">
+<link rel="icon" type="image/png" href="{{ site.baseurl }}/images/favicons/favicon-16x16.png" sizes="16x16">
 <link rel="manifest" href="{{ site.baseurl }}/images/favicons/manifest.json">
 <meta name="msapplication-TileColor" content="#2b5797">
 <meta name="msapplication-TileImage" content="{{ site.baseurl }}/images/favicons/mstile-144x144.png">


### PR DESCRIPTION
Fix 404 for four of the favicons. It's favicon-size.png instead of facicons-size.png 