### PR TITLE
Update AWS AMI tables to use Spinnaker-Ubuntu-14.04-25 AMIs

### DIFF
--- a/online_docs/quick_ref/ami_table.md
+++ b/online_docs/quick_ref/ami_table.md
@@ -13,12 +13,12 @@ lang: en
 
 | Region           | Name                       | Ubuntu Version   | Instance Type   | AMI ID                                                                                               |
 | ---------------- | -------------------------- | ---------------- | --------------- | --------------                                                                                       |
-| us-east-1        | Spinnaker-Ubuntu-14.04-24  | 14.04 LTS        | HVM             | [ami-13685579](https://console.aws.amazon.com/ec2/home?region=us-east-1#launchAmi=ami-13685579)      |
-| ap-northeast-1   | Spinnaker-Ubuntu-14.04-24  | 14.04 LTS        | HVM             | [ami-268e8d48](https://console.aws.amazon.com/ec2/home?region=ap-northeast-1#launchAmi=ami-268e8d48) |
-| eu-west-1        | Spinnaker-Ubuntu-14.04-24  | 14.04 LTS        | HVM             | [ami-4060dc33](https://console.aws.amazon.com/ec2/home?region=eu-west-1#launchAmi=ami-4060dc33)      |
-| ap-southeast-1   | Spinnaker-Ubuntu-14.04-24  | 14.04 LTS        | HVM             | [ami-4527ee26](https://console.aws.amazon.com/ec2/home?region=ap-southeast-1#launchAmi=ami-4527ee26) |
-| ap-southeast-2   | Spinnaker-Ubuntu-14.04-24  | 14.04 LTS        | HVM             | [ami-f01f3993](https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-f01f3993) |
-| us-west-2        | Spinnaker-Ubuntu-14.04-24  | 14.04 LTS        | HVM             | [ami-4340a223](https://console.aws.amazon.com/ec2/home?region=us-west-2#launchAmi=ami-4340a223)      |
-| us-west-1        | Spinnaker-Ubuntu-14.04-24  | 14.04 LTS        | HVM             | [ami-1c04747c](https://console.aws.amazon.com/ec2/home?region=us-west-1#launchAmi=ami-1c04747c)      |
-| eu-central-1     | Spinnaker-Ubuntu-14.04-24  | 14.04 LTS        | HVM             | [ami-4aa14425](https://console.aws.amazon.com/ec2/home?region=eu-central-1#launchAmi=ami-4aa14425)   |
-| sa-east-1        | Spinnaker-Ubuntu-14.04-24  | 14.04 LTS        | HVM             | [ami-45951729](https://console.aws.amazon.com/ec2/home?region=sa-east-1#launchAmi=ami-45951729)      |
+| us-east-1        | Spinnaker-Ubuntu-14.04-24  | 14.04 LTS        | HVM             | [ami-1cfbc276](https://console.aws.amazon.com/ec2/home?region=us-east-1#launchAmi=ami-1cfbc276)      |
+| ap-northeast-1   | Spinnaker-Ubuntu-14.04-24  | 14.04 LTS        | HVM             | [ami-ca0509a4](https://console.aws.amazon.com/ec2/home?region=ap-northeast-1#launchAmi=ami-ca0509a4) |
+| eu-west-1        | Spinnaker-Ubuntu-14.04-24  | 14.04 LTS        | HVM             | [ami-104bf563](https://console.aws.amazon.com/ec2/home?region=eu-west-1#launchAmi=ami-104bf563)      |
+| ap-southeast-1   | Spinnaker-Ubuntu-14.04-24  | 14.04 LTS        | HVM             | [ami-4bd91128](https://console.aws.amazon.com/ec2/home?region=ap-southeast-1#launchAmi=ami-4bd91128) |
+| ap-southeast-2   | Spinnaker-Ubuntu-14.04-24  | 14.04 LTS        | HVM             | [ami-f87b5a9b](https://console.aws.amazon.com/ec2/home?region=ap-southeast-2#launchAmi=ami-f87b5a9b) |
+| us-west-2        | Spinnaker-Ubuntu-14.04-24  | 14.04 LTS        | HVM             | [ami-65db3705](https://console.aws.amazon.com/ec2/home?region=us-west-2#launchAmi=ami-65db3705)      |
+| us-west-1        | Spinnaker-Ubuntu-14.04-24  | 14.04 LTS        | HVM             | [ami-32d4a452](https://console.aws.amazon.com/ec2/home?region=us-west-1#launchAmi=ami-32d4a452)      |
+| eu-central-1     | Spinnaker-Ubuntu-14.04-24  | 14.04 LTS        | HVM             | [ami-4945a026](https://console.aws.amazon.com/ec2/home?region=eu-central-1#launchAmi=ami-4945a026)   |
+| sa-east-1        | Spinnaker-Ubuntu-14.04-24  | 14.04 LTS        | HVM             | [ami-fd7bf991](https://console.aws.amazon.com/ec2/home?region=sa-east-1#launchAmi=ami-fd7bf991)      |


### PR DESCRIPTION
Hey, all.

Recently I needed to use newer version of Spinnaker and I've found out that AMI listed in docs have not the latest versions of AMIs with Spinnaker. Here is updated list.

Best wishes,
Alex L.