### PR TITLE
feat(nav): Change active style

### DIFF
--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -441,16 +441,11 @@
   }
 
   .active {
-    margin-left: -0.5em;
-    padding-left: 0.5em;
-    padding-right: 0.5em;
-    color: #fff;
     font-weight: bold;
-    background: $primary-color;
-    border-radius: $border-radius;
+    color: $info-color;
 
     &:hover {
-      color: #fff;
+      color: black;
     }
   }
 


### PR DESCRIPTION
I changed the color to be consistent with the navigation theme that seems to center around using that blue for breadcrumbs: 

# Before
![mqw6undskuq](https://cloud.githubusercontent.com/assets/4874941/25445546/a7c29dea-2a7c-11e7-8702-70681b5c4f27.png)

# After
![dnfbeb1koqh](https://cloud.githubusercontent.com/assets/4874941/25445557/ae0db63a-2a7c-11e7-85d8-e318e4073cbf.png)
