### PR TITLE
fix(community): Don't squash changes until they're ready to be merged

### DIFF
--- a/community/contributing/submitting.md
+++ b/community/contributing/submitting.md
@@ -93,7 +93,7 @@ Note that at minimum, 'BREAKING CHANGE' must be specified on the last line. The 
 
 * Provide a descriptive title for your changes.
 * Add inline code comments to changes that might not be obvious.
-* Squash your commits as you keep adding changes.
+* Squash your commits when you first submit your PR, and again when it's ready to be merged.
 * Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days. 
 
 Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

--- a/community/contributing/submitting.md
+++ b/community/contributing/submitting.md
@@ -93,7 +93,7 @@ Note that at minimum, 'BREAKING CHANGE' must be specified on the last line. The 
 
 * Provide a descriptive title for your changes.
 * Add inline code comments to changes that might not be obvious.
-* Squash your commits when you first submit your PR, and again when it's ready to be merged.
+* Squash your commits when you first submit your PR, and again when it's ready to be merged. It's much easier to review incremental changes to feedback when the commits are kept separate.
 * Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days. 
 
 Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.


### PR DESCRIPTION
Generally it's easier to review PRs when you can see what incremental changes the submitter has made in response to your feedback.