### PR TITLE
fix(landing page): Puts masthead and cloud provider logos into same c…

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -3,7 +3,7 @@
     <div class="masthead__menu">
       <nav id="site-nav" class="greedy-nav">
         <a class="site-title" href="{{ '/' | absolute_url }}">
-          <img src="{{ site.url}}/assets/images/spinnaker-logo-transparent-color.png" alt="Spinnaker Logo">
+          <img src="{{ site.url}}/assets/images/spinnaker-text-white.svg" alt="Spinnaker Logo">
         </a>
         <ul class="visible-links">
           {% for link in site.data.navigation.main %}

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -214,7 +214,7 @@
     border: 0;
     outline: none;
     color: #fff;
-    background-color: $masthead-link-color;
+    background-color: transparent;
     cursor: pointer;
   }
 

--- a/_sass/_spinnaker.scss
+++ b/_sass/_spinnaker.scss
@@ -90,7 +90,7 @@ $spin-light-blue: #e2f3f6;
 $spin-dark-blue: #139bb4;
 
 @mixin fullscreen {
-  width: 100vw;
+  width: 100%;
   position: absolute;
   left: 0;
 }
@@ -103,10 +103,32 @@ $header-height: 400px;
   background-color: $spin-dark-blue;
   top: 0;
 
-  &__spin_text {
-    left: 40px;
-    top: 20px;
-    position: absolute;
+  &__inner_wrap {
+    @include container;
+    @include clearfix;
+
+    padding: 0 0.5em;
+
+    @include breakpoint($x-large) {
+      max-width: $x-large;
+    }
+
+    a:hover {
+      text-decoration: none;
+
+      img {
+        box-shadow: none;
+      }
+    }
+  }
+
+  .masthead {
+    border-bottom-width: 0;
+    background-color: transparent;
+  }
+
+  .greedy-nav {
+    background-color: transparent;
   }
 
   &__swoosh {
@@ -118,15 +140,14 @@ $header-height: 400px;
   }
 
   &__text {
-    position: absolute;
-    top: 150px;
-    left: 40px;
+    position: relative;
+    margin-top: 3rem;
 
     h1, h2 {
       border: none;
       color: white;
       font-weight: 100;
-      margin: 0;
+      margin: 10px;
       line-height: 1;
     }
 
@@ -143,29 +164,12 @@ $header-height: 400px;
     margin-top: $header-height + 50px;
   }
 
-  &__nav {
-    @extend .greedy-nav;
-    background-color: transparent;
-    margin-top: 10px;
-    font-weight: 600;
-
-    a {
-      color: white;
-      font-size: large;
-      text-transform: uppercase;
-      &:hover {
-        text-decoration: none;
-        color: white !important;
-      }
-      &:before {
-        background: white !important;
-      }
-    }
-  }
-
   ul.spin_call_to_action {
     list-style: none;
-    margin-top: 280px;
+    margin: 0 10px;
+    padding: 0;
+    position: absolute;
+    bottom: 10px;
 
     li {
       display: block;
@@ -294,6 +298,13 @@ $white-bar-height: 150px;
 $cloud-providers-bar-height: $blue-bar-height + $white-bar-height;
 
 .spin_cloud_providers {
+  &__swoosh {
+    position: absolute;
+    left: 0;
+    z-index: 10;
+    margin-top: 8em;
+  }
+
   &__blue {
     @include fullscreen();
     background-color: $spin-light-blue;
@@ -301,6 +312,17 @@ $cloud-providers-bar-height: $blue-bar-height + $white-bar-height;
     > img {
       height: 110%;
       margin-top: 50px;
+    }
+  }
+
+  &__wrapper {
+    @include container;
+    @include clearfix;
+
+    padding: 0 0.5em;
+
+    @include breakpoint($x-large) {
+      max-width: $x-large;
     }
   }
 
@@ -316,22 +338,20 @@ $cloud-providers-bar-height: $blue-bar-height + $white-bar-height;
     font-weight: 100;
     margin-left: 0;
     font-family: 'Source Sans Pro', sans-serif;
-    position: absolute;
-    left: 100px;
-    top: 30px;
+    margin-top: 1em;
   }
 
-  .spin_row {
-    position: absolute;
-    top: 150px;
-    left: 12vw;
+  .provider_row {
+    margin-bottom: 1rem;
+    @include clearfix();
+    margin-top: 100px;
   }
 
   .spin_cloud_provider {
 
     &__wrapper {
       float: left;
-      width: span(2 of 12);
+      width: span(1 of 5);
       img {
         display: block;
         margin: auto;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -94,8 +94,8 @@ $xing-color                 : #006567 !default;
 $link-color                 : $info-color !default;
 $link-color-hover           : mix(#000, $link-color, 25%) !default;
 $link-color-visited         : mix(#fff, $link-color, 25%) !default;
-$masthead-color             : #d8e8ec !default;
-$masthead-link-color        : #229cb3 !default;
+$masthead-color             : #139bb4;
+$masthead-link-color        : white;
 $masthead-link-color-hover  : #39546a !default;
 
 

--- a/index.md
+++ b/index.md
@@ -112,37 +112,20 @@ waze_case_study:
 
 
 <div class="spin_header">
-   <img class="spin_header__swoosh" src="{{ "assets/images/top-right-swoosh.svg" | absolute_url }}" alt="Spinnaker Swoosh"/>
-   <img class="spin_header__spin_text" src="{{ "assets/images/spinnaker-text-white.svg" | absolute_url }}" alt="Spinnaker Logo"/>
-   <div class="spin_header__text">
-       <h1>Continuous Delivery for Enterprise</h1>
-       <h2>Fast, safe, repeatable deployments</h2>
-   </div>
-   <div class="masthead__menu">
-     <nav id="site-nav" class="spin_header__nav">
-       <ul class="visible-links">
-         {% for link in site.data.navigation.main %}
-           {% if link.url contains 'http' %}
-             {% assign domain = '' %}
-           {% else %}
-             {% assign domain = site.url | append: site.baseurl %}
-           {% endif %}
-           <li class="masthead__menu-item">
-             {% if page.url contains link.url %}
-               <a href="{{ domain }}{{ link.url }}" class="active">{{ link.title | capitalize }}</a>
-             {% else %}
-               <a href="{{ domain }}{{ link.url }}">{{ link.title | capitalize }}</a>
-             {% endif %}
-           </li>
-         {% endfor %}
-       </ul>
-       <ul class="hidden-links hidden"></ul>
-     </nav>
-   </div>
-   <ul class="spin_call_to_action">
-     <li><a href="/concepts/">GET STARTED</a></li>
-     <li><a href="/setup/">INSTALL LATEST</a></li>
-   </ul>
+  <img class="spin_header__swoosh" src="{{ "assets/images/top-right-swoosh.svg" | absolute_url }}" alt="Spinnaker Swoosh"/>
+  <div class="spin_header__inner_wrap">
+    
+    {% include masthead.html %}
+    
+    <div class="spin_header__text">
+      <h1>Continuous Delivery for Enterprise</h1>
+      <h2>Fast, safe, repeatable deployments</h2>
+    </div>
+    <ul class="spin_call_to_action">
+      <li><a href="/concepts/">GET STARTED</a></li>
+      <li><a href="/setup/">INSTALL LATEST</a></li>
+    </ul>
+  </div>
 </div>
 
 <div class="spin_header__push_down">
@@ -153,17 +136,19 @@ waze_case_study:
 {% include splash_feature_row id="active_community_row" type="right" %}
 </div>
 <div class="spin_cloud_providers">
-    <div class="spin_cloud_providers__blue">
-        <h1 class="spin_cloud_providers__header">Supported Cloud Providers</h1>
-        <img src="{{ "assets/images/left-swoosh.svg" | absolute_url }}" alt="Spinnaker Swoosh"/>
-        <div class="spin_row">
-            {% include spinnaker_cloud_provider id="aws_provider" %}
-            {% include spinnaker_cloud_provider id="gcp_provider" %}
-            {% include spinnaker_cloud_provider id="k8s_provider" %}
-            {% include spinnaker_cloud_provider id="azure_provider" %}
-            {% include spinnaker_cloud_provider id="os_provider" %}
-        </div>
+  <img class="spin_cloud_providers__swoosh" src="{{ "assets/images/left-swoosh.svg" | absolute_url }}" alt="Spinnaker Swoosh"/>
+  <div class="spin_cloud_providers__blue">
+    <div class="spin_cloud_providers__wrapper">
+      <h1 class="spin_cloud_providers__header">Supported Cloud Providers</h1>
+      <div class="provider_row">
+          {% include spinnaker_cloud_provider id="aws_provider" %}
+          {% include spinnaker_cloud_provider id="gcp_provider" %}
+          {% include spinnaker_cloud_provider id="k8s_provider" %}
+          {% include spinnaker_cloud_provider id="azure_provider" %}
+          {% include spinnaker_cloud_provider id="os_provider" %}
+      </div>
     </div>
+  </div>  
 </div>
 
 <h1 class="spin__heading spin_cloud_providers__push_down">Features List</h1>


### PR DESCRIPTION
…entered container as the rest of the content. Changes masthead color to be consistent with new landing page.

Landing Page:
![rfdepjzxahm](https://cloud.githubusercontent.com/assets/13141550/26733450/dca66e96-4788-11e7-8e7d-d28fa7b109ea.png)

Cloud providers:
![ronsczecxjy](https://cloud.githubusercontent.com/assets/13141550/26733452/ddac9892-4788-11e7-8fe3-4c7876112ea5.png)

Mobile:
![d4612di0eid](https://cloud.githubusercontent.com/assets/13141550/26733456/ded01d16-4788-11e7-99eb-1e74ddb5c104.png)

Changed masthead to match the look and feel:

![xldkhrtkqh2](https://cloud.githubusercontent.com/assets/13141550/26733513/0af9d206-4789-11e7-8458-efe3eb6b1034.png)

