### PR TITLE
chore(versions): Deprecates old version, leaving 0.6.1 as latest stable

### DIFF
--- a/_changelogs/0.6.0-changelog.md
+++ b/_changelogs/0.6.0-changelog.md
@@ -1,7 +1,7 @@
 ---
 title: Version 0.6.0
 date: 2017-05-31 11:09:41 
-tags: "changelogs 0.6"
+tags: "changelogs 0.6 deprecated"
 ---
 
 <script src="https://gist.github.com/spinnaker-release/9cd8fd9363f8ab3fec8c50790ca3710b.js"></script>

--- a/_changelogs/2017-05-15-0.4.0-changelog.md
+++ b/_changelogs/2017-05-15-0.4.0-changelog.md
@@ -1,7 +1,7 @@
 ---
 title: Version 0.4.0
 date: 2017-05-15 18:36:04 
-tags: "changelogs 0.4"
+tags: "changelogs 0.4 deprecated" 
 ---
 
 <script src="https://gist.github.com/spinnaker-release/74b51f19fbb198e3cc0f927bf770f7cf.js"></script>

--- a/_changelogs/2017-05-15-0.4.1-changelog.md
+++ b/_changelogs/2017-05-15-0.4.1-changelog.md
@@ -1,7 +1,7 @@
 ---
 title: Version 0.4.1
 date: 2017-05-15 20:45:28 
-tags: "changelogs 0.4"
+tags: "changelogs 0.4 deprecated"  
 ---
 
 <script src="https://gist.github.com/spinnaker-release/521b65f64e1451ecfeb34bcce8ba5a60.js"></script>

--- a/_changelogs/2017-05-22-0.5.0-changelog.md
+++ b/_changelogs/2017-05-22-0.5.0-changelog.md
@@ -1,7 +1,7 @@
 ---
 title: Version 0.5.0
 date: 2017-05-22 16:00:15 
-tags: "changelogs 0.5"
+tags: "changelogs 0.5 deprecated" 
 ---
 
 <script src="https://gist.github.com/spinnaker-release/e6611528dbe0e6f87daf4cd579f4fffa.js"></script>


### PR DESCRIPTION
@spinnaker/google-reviewers FYI