### PR TITLE
Add trailing slash to CI setup links

### DIFF
--- a/setup/ci/index.md
+++ b/setup/ci/index.md
@@ -22,5 +22,5 @@ independently of one-another, enumerated below.
 
 These are the CI systems currently supported by Spinnaker:
 
-* [Jenkins](/setup/ci/jenkins)
-* [Travis CI](/setup/ci/travis)
+* [Jenkins](/setup/ci/jenkins/)
+* [Travis CI](/setup/ci/travis/)


### PR DESCRIPTION
Without the trailing slash, we seem to redirect to /

Fixes #201 