### PR TITLE
Fix Links to Codelabs

### DIFF
--- a/guides/tutorials/codelabs/index.md
+++ b/guides/tutorials/codelabs/index.md
@@ -9,12 +9,12 @@ Run through these codelabs to get hands-on experience with Spinnaker in a guided
 
 ## Table of Contents
 
-* [Bake and Deploy Pipeline](./bake-and-deploy-pipeline) - set up a Spinnaker pipeline that bakes a virtual machine (VM) image containing redis, then deploys that image to a test cluster
-* [Hello Deployment](./hello-deployment) - run through the workflow of setting up an example application deployment 
-* [GCE Source To Prod](./gce-source-to-prod) - create a cohesive workflow which takes source code and builds, tests and promotes it to production with VMs in GCE
-* [Kubernetes Source To Prod](./kubernetes-source-to-prod) - create a set of basic pipelines for deploying code from a Github repo to a Kubernetes cluster in the form of a Docker container
-* [OpenStack Source To Prod](./openstack-source-to-prod) - create a cohesive workflow which takes source code and builds, tests, and promotes it to production on OpenStack
-* [Continuous Delivery with Containers on GCP](./gcp-kubernetes-source-to-prod) - set up a source-to-prod continuous delivery flow for a hello world app deployed via containers, on the Google Cloud Platform
-* [Continuous Delivery to Kubernetes on Azure](./azure-kubernetes-source-to-prod) - deploy a Dev Ops VM with a sample source-to-prod pipeline targeting Kubernetes on Azure
-* [Continuous Delivery to Azure VM Scale Set](./azure-vmss-source-to-prod) - deploy a Dev Ops VM with a sample source-to-prod pipeline targeting Virtual Machine Scale Set on Azure 
-* [App Engine Source To Prod](./appengine-source-to-prod) - create a workflow to safely deploy to App Engine from source code.
+* [Bake and Deploy Pipeline](./bake-and-deploy-pipeline/) - set up a Spinnaker pipeline that bakes a virtual machine (VM) image containing redis, then deploys that image to a test cluster
+* [Hello Deployment](./hello-deployment/) - run through the workflow of setting up an example application deployment 
+* [GCE Source To Prod](./gce-source-to-prod/) - create a cohesive workflow which takes source code and builds, tests and promotes it to production with VMs in GCE
+* [Kubernetes Source To Prod](./kubernetes-source-to-prod/) - create a set of basic pipelines for deploying code from a Github repo to a Kubernetes cluster in the form of a Docker container
+* [OpenStack Source To Prod](./openstack-source-to-prod/) - create a cohesive workflow which takes source code and builds, tests, and promotes it to production on OpenStack
+* [Continuous Delivery with Containers on GCP](./gcp-kubernetes-source-to-prod/) - set up a source-to-prod continuous delivery flow for a hello world app deployed via containers, on the Google Cloud Platform
+* [Continuous Delivery to Kubernetes on Azure](./azure-kubernetes-source-to-prod/) - deploy a Dev Ops VM with a sample source-to-prod pipeline targeting Kubernetes on Azure
+* [Continuous Delivery to Azure VM Scale Set](./azure-vmss-source-to-prod/) - deploy a Dev Ops VM with a sample source-to-prod pipeline targeting Virtual Machine Scale Set on Azure 
+* [App Engine Source To Prod](./appengine-source-to-prod/) - create a workflow to safely deploy to App Engine from source code.


### PR DESCRIPTION
The links to the codelabs are currently broken. Without the trailing slash the links are being redirected to just https://www.spinnaker.io/