### PR TITLE
Fixes typo in Halyard Docs.

### DIFF
--- a/reference/halyard/index.md
+++ b/reference/halyard/index.md
@@ -8,7 +8,7 @@ sidebar:
 {% include toc %}
 
 This is the reference documentation for Halyard, and will go into more detail
-than is needed to deploy most Spinnaker environemnts. If you're a new user
+than is needed to deploy most Spinnaker environments. If you're a new user
 looking for instructions for how to use Halyard to deploy Spinnaker, checkout
 the [setup instructions](/setup/install/) first.
 


### PR DESCRIPTION
Changes "environemnts" to "environments."