### PR TITLE
fix(setup/provider/openstack): Change Glance v2 to Glance v1

### DIFF
--- a/setup/providers/openstack.md
+++ b/setup/providers/openstack.md
@@ -19,7 +19,7 @@ here is a list of API versions that are required to be enabled:
 * Networking v2
 * Orchestration (Heat)
 * Ceilometer
-* Glance v2
+* Glance v1
 
 You will need an account admin permissions for Spinnaker to use. You can download the [openrc](https://docs.openstack.org/user-guide/common/cli-set-environment-variables-using-openstack-rc.html) from your Horizon UI. To test your setup, use the the [OpenStack command line client](https://docs.openstack.org/developer/python-openstackclient/).
 


### PR DESCRIPTION
Prerequisites[1] of Deploy OpenStack is written to need "Glance v2",
however clouddriver-openstack use Glance v1 client now.
Glance v2 cliente isn't implemented in clouddriver-openstack.

resolve spinnaker/spinnaker#1750