### PR TITLE
Update S3 documentation about the permissions

### DIFF
--- a/setup/storage/s3.md
+++ b/setup/storage/s3.md
@@ -12,9 +12,14 @@ storage source means that Spinnaker will store all of its persistent data in a
 ## Prerequisites
 
 You need an [AWS Account](https://aws.amazon.com/account/), and an associated
-access key (secret access key & access key id). The service in charge of
-storage does not support STS AssumeRole style auth, so the access key & id are
-required.
+access key (secret access key & access key id).
+
+## Notes
+1. The service in charge of storage does not support STS AssumeRole style auth,
+so the access key & id are required. Ignore `--assume-role` option in the CLI.
+2. You need to provide access key with permissions on-par with the Spinnaker
+instance role/user. As this access key will be also used by CloudDriver to
+manage all the Spinnaker created instances.
 
 ## Editing your Storage Settings
 


### PR DESCRIPTION
The documentation is misleading in the sense that the access key needed is only needed for S3 access, when in reality it is also used for the CloudDriver. This change mentions the permission needed for this to work properly.
See also: spinnaker/halyard#565