### PR TITLE
fix(jekyll): Lock version to 3.4.4 because 3.5 is broken

### DIFF
--- a/minimal-mistakes-jekyll.gemspec
+++ b/minimal-mistakes-jekyll.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
     f.match(%r{^(assets|_(includes|layouts|sass)/|(LICENSE|README|CHANGELOG)((\.(txt|md|markdown)|$)))}i)
   end
 
-  spec.add_runtime_dependency "jekyll", "~> 3.3"
+  spec.add_runtime_dependency "jekyll", "3.4.4"
   spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.0"
   spec.add_runtime_dependency "jekyll-gist", "~> 1.4"


### PR DESCRIPTION
See https://github.com/jekyll/jekyll/issues/6154 for more information. See https://travis-ci.org/spinnaker/spinnaker.github.io/builds/244540749#L301 for an example of our build failing with jekyll 3.5