### PR TITLE
fix(setup/provider/openstack): Add Telemetry Alarming(Aodh) to prerequisites

### DIFF
--- a/setup/providers/openstack.md
+++ b/setup/providers/openstack.md
@@ -19,6 +19,7 @@ here is a list of API versions that are required to be enabled:
 * Networking v2
 * Orchestration (Heat)
 * Ceilometer
+* Telemetry Alarming (Aodh)
 * Glance v1
 
 You will need an account admin permissions for Spinnaker to use. You can download the [openrc](https://docs.openstack.org/user-guide/common/cli-set-environment-variables-using-openstack-rc.html) from your Horizon UI. To test your setup, use the the [OpenStack command line client](https://docs.openstack.org/developer/python-openstackclient/).


### PR DESCRIPTION
clouddriver-openstack needs to Telemetry Alarming(Aodh),
however prerequisites[1] of Deploy OpenStack don't show it.

[1]:https://www.spinnaker.io/setup/providers/openstack/

resolve spinnaker/spinnaker#1757