### PR TITLE
Remove localhost prepend from docker run command

### DIFF
--- a/setup/install/halyard.md
+++ b/setup/install/halyard.md
@@ -70,7 +70,7 @@ Now, run the Halyard docker container, while mounting that Halyard config
 directory for your container:
 
 ```
-docker run -p localhost:8084:8084 -p localhost:9000:9000 \
+docker run -p 8084:8084 -p 9000:9000 \
     --name halyard --rm \
     -v ~/.hal:/root/.hal \
     gcr.io/spinnaker-marketplace/halyard:stable


### PR DESCRIPTION
When specifying the ports to expose, there is no need to prepend localhost. The command doesn't run in docker 17.06. Here is the output:
docker run -p localhost:8084:8084 -p localhost:9000:9000 \
>     --name halyard --rm \
>     -v ~/.hal:/root/.hal \
>     gcr.io/spinnaker-marketplace/halyard:stable
docker: Invalid ip address: localhost.
See 'docker run --help'.