### PR TITLE
Add DC/OS as a cloud provider in navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -58,6 +58,8 @@ setup:
         url: /setup/providers/aws/
       - title: Azure
         url: /setup/providers/azure/
+      - title: DC/OS
+        url: /setup/providers/dcos/
       - title: Docker Registry
         url: /setup/providers/docker-registry/
       - title: Google App Engine


### PR DESCRIPTION
Adding the DC/OS cloud provider to the navigation bar. Support for this cloud provider was added in [1.3.0 release](https://www.spinnaker.io/community/releases/versions/1-3-0-changelog).