### PR TITLE
Improved halyard container handling

### DIFF
--- a/setup/install/halyard.md
+++ b/setup/install/halyard.md
@@ -73,6 +73,7 @@ directory for your container:
 docker run -p 8084:8084 -p 9000:9000 \
     --name halyard --rm \
     -v ~/.hal:/root/.hal \
+    -it \
     gcr.io/spinnaker-marketplace/halyard:stable
 ```
 


### PR DESCRIPTION
Its not possible to terminate the halyard container using `CTRL+C` and terminal output is also coloured