### PR TITLE
Add missing authz config for github groups

### DIFF
--- a/setup/security/authorization/github-teams/index.md
+++ b/setup/security/authorization/github-teams/index.md
@@ -32,7 +32,9 @@ ORG=myorg        # GitHub Organization
 hal config security authz github edit \
     --accessToken $TOKEN \
     --organization $ORG
-    
+
+hal config security authz edit --type github
+
 hal config security authz enable
 ```
 


### PR DESCRIPTION
Missing step which leaves service as EXTERNAL.  Need to set it as github.