### PR TITLE
Deploy to RBAC enabled cluster on Google Kubernetes Engine

### DIFF
--- a/setup/quickstart/halyard-gke-deploy-rbac/index.md
+++ b/setup/quickstart/halyard-gke-deploy-rbac/index.md
@@ -24,137 +24,137 @@ At the end of this guide you will have:
 
 ## Part 0: Prerequisites
 
-* A GCP project (referred to as $GCP_PROJECT) running a Spinnaker [GKE cluster with halyard](/setup/quickstart/halyard-gke/)
+* A GCP project (referred to as $GCP_PROJECT) running a Spinnaker [GKE cluster with Halyard](/setup/quickstart/halyard-gke/)
 * Another K8s cluster (referred to as $K8_TEST) running with Kubernetes version > 1.6 on another GCP project ($GCP_TEST)
 
 ## Part 1: Configure gcloud
 
 1. Make sure that you are authenticated against the test cluster ($K8_TEST). 
 
-```bash
-gcloud info
-```
+   ```bash
+   gcloud info
+   ```
 
-If you are unfamiliar with how to use multiple projects with ```bash gcloud ``` you can use this [guide](https://cloud.google.com/sdk/docs/managing-configurations) to get started.
+   If you are unfamiliar with how to use multiple projects with ```bash gcloud ``` you can use this [guide](https://cloud.google.com/sdk/docs/managing-configurations) to get started.
 
 2. Set your zone and project variables and get the credentials for the Kubernetes cluster:
 
-```bash
-GCP_PROJECT=my-spinnaker-project
-ZONE=us-central1-f
-K8_TEST=my-test-cluster
-GCP_TEST=my-test-project
-gcloud container clusters get-credentials $K8_TEST --zone $ZONE --project $GCP_TEST
-```
+  ```bash
+  GCP_PROJECT=my-spinnaker-project
+  ZONE=us-central1-f
+  K8_TEST=my-test-cluster
+  GCP_TEST=my-test-project
+  gcloud container clusters get-credentials $K8_TEST --zone $ZONE --project $GCP_TEST
+  ```
 
 ## Part 2: Add Service account to GCP
 
 1. Create the service account in the GCP test project.
 
-````bash
-HALYARD_SA=halyard-service-account
+  ```bash
+  HALYARD_SA=halyard-service-account
 
-#Get the SA email from the Spinnaker project
-HALYARD_SA_EMAIL=$(gcloud iam service-accounts list \
+  #Get the SA email from the Spinnaker project
+  HALYARD_SA_EMAIL=$(gcloud iam service-accounts list \
     --project=$GCP_PROJECT \
     --filter="displayName:$HALYARD_SA" \
     --format='value(email)')
 
-#Add policy bindings in the Test project
-gcloud projects add-iam-policy-binding $GCP_TEST \
+  #Add policy bindings in the Test project
+  gcloud projects add-iam-policy-binding $GCP_TEST \
     --role roles/iam.serviceAccountKeyAdmin \
     --member serviceAccount:$HALYARD_SA_EMAIL
 
-gcloud projects add-iam-policy-binding $GCP_TEST \
+  gcloud projects add-iam-policy-binding $GCP_TEST \
     --role roles/container.admin \
     --member serviceAccount:$HALYARD_SA_EMAIL
-```` 
+  ``` 
 ## Part 3: Add a service account (SA) to Kubernetes
 
 1. Next we need to add a service account to Kubernetes that will handle the authorization inside the Kubernetes cluster.
 Create a file, spinnaker-service-account.yaml, with the following content:
 
-```yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: spinnaker-service-account
-  namespace: default
-```
+  ```yaml
+  apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: spinnaker-service-account
+    namespace: default
+  ```
 
 2. Apply the service account
 
-```bash
-kubectl apply -f ./spinnaker-service-account.yaml
-```
+  ```bash
+  kubectl apply -f ./spinnaker-service-account.yaml
+  ```
 
 3. Then we need to set access for Spinnaker to edit the cluster so it can manage deployments there.
 
-```bash
-kubectl create clusterrolebinding \
+  ```bash
+  kubectl create clusterrolebinding \
     --user system:serviceaccount:default:spinnaker-service-account \
     spinnaker \
     --clusterrole edit
-```
+  ```
     
-If you can't create a ```bash clusterrolebinding``` make sure that you have the right permissions.
-The following command enables you to make other roles in the cluster:
+  If you can't create a ```bash clusterrolebinding``` make sure that you have the right permissions.
+  The following command enables you to make other roles in the cluster:
 
-```bash
-#replace your.google.cloud.email@example.org with your Gcloud account
-kubectl create clusterrolebinding user-cluster-admin-binding \
+  ```bash
+  #replace your.google.cloud.email@example.org with your Gcloud account
+  kubectl create clusterrolebinding user-cluster-admin-binding \
     --clusterrole=cluster-admin \
     --user=your.google.cloud.email@example.org
-```
+  ```
       
 4. Now we want to get the secret for the service account that was created by Kubernetes. 
-Store it somewhere safe for the next part.
+  Store it somewhere safe for the next part.
 
-```bash
-#Get the name of the secret
-SERVICE_ACCOUNT_TOKEN=`kubectl get serviceaccounts spinnaker-service-account -o jsonpath='{.secrets[0].name}'`
+  ```bash
+  #Get the name of the secret
+  SERVICE_ACCOUNT_TOKEN=`kubectl get serviceaccounts spinnaker-service-account -o jsonpath='{.secrets[0].name}'`
 
-#Get token and base64 decode it since all secrets are stored in base64 in Kubernetes and store it somewhere safe for later use
-kubectl get secret $SERVICE_ACCOUNT_TOKEN -o jsonpath='{.data.token}' | base64 -D
-```
+  #Get token and base64 decode it since all secrets are stored in base64 in Kubernetes and store it somewhere safe for later use
+  kubectl get secret $SERVICE_ACCOUNT_TOKEN -o jsonpath='{.data.token}' | base64 -D
+  ```
 
 ## Part 4: Add provider to Halyard
 
 1. SSH into your halyard instance.
 
-```bash
-gcloud compute ssh $HALYARD_HOST \
+  ```bash
+  gcloud compute ssh $HALYARD_HOST \
     --project=$GCP_PROJECT \
     --ssh-flag="-L 9000:localhost:9000" \
     --ssh-flag="-L 8084:localhost:8084"
-```
+  ```
 
 2. Add the credentials to the kubeconfig file.
 
-```bash
-gcloud container clusters get-credentials $K8_TEST --project $GCP_TEST --zone us-central1-f
-```
+  ```bash
+  gcloud container clusters get-credentials $K8_TEST --project $GCP_TEST --zone us-central1-f
+  ```
 
 3. Get the new user profile that was created by ```bash gcloud``` and add the token you received before in part 3 step 4.
 
-```bash
-TEST_USER_PROFILE=`kubectl config current-context`
-kubectl config set-credentials $TEST_USER_PROFILE --token replace-with-your-token-here
-```
+  ```bash
+  TEST_USER_PROFILE=`kubectl config current-context`
+  kubectl config set-credentials $TEST_USER_PROFILE --token replace-with-your-token-here
+  ```
 
 4. Add the new Kubernetes provider.
 
-```bash
-hal config provider kubernetes account add my-test-account \
+  ```bash
+  hal config provider kubernetes account add my-test-account \
     --docker-registries my-gcr-account \
     --context $(kubectl config current-context)
-```
+  ```
 
 5. Apply your changes to Spinnaker.
 
-```bash
-hal deploy apply
-```
+  ```bash
+  hal deploy apply
+  ```
 
 
 

--- a/setup/quickstart/halyard-gke-deploy-rbac/index.md
+++ b/setup/quickstart/halyard-gke-deploy-rbac/index.md
@@ -1,0 +1,161 @@
+---
+layout: single
+title:  "Deploy to Google Kubernetes Engine with RBAC"
+sidebar:
+  nav: setup
+---
+
+{% include toc %}
+
+# Deploy to Google Kubernetes Engine with RBAC
+
+If you've deployed Spinnaker already using [this
+codelab](/setup/quickstart/halyard-gke) you're left with a Spinnaker that can only deploy to the cluster that Spinnaker is deployed in.
+In many cases you want to deploy to clusters in another GCP project that also have Kubernetes RBAC enabled.
+
+In this codelab, we will enable Spinnaker to push your containers to another GCP project that have a cluster secured by RBAC. This codelab will allow Spinnaker to be able to manipulate all deployments in the target cluster. 
+You may want to limit Spinnaker further but how to do that is not covered by this tutorial. 
+This guide won't show you how to setup Spinnaker in a RBAC cluster.
+
+## Overview
+
+At the end of this guide you will have
+
+* A new Kubernetes provider with RBAC enabled
+* Ability to deploy to a cluster in another GCP project
+
+## Part 0: Prerequisites
+
+A GCP project (referred to as $GCP_PROJECT) running a Spinnaker [GKE cluster with halyard](/setup/quickstart/halyard-gke/)
+
+Another K8s cluster (referred to as $K8_TEST) running with Kubernetes version > 1.6 on another GCP project ($GCP_TEST)
+
+## Part 1: Configure Gcloud
+
+Make sure that you are authenticated against the test cluster ($K8_TEST). 
+
+```bash
+gcloud info
+```
+
+If you are unfamiliar with how to use multiple project with gcloud you can use this [guide](https://cloud.google.com/sdk/docs/managing-configurations) to get started
+
+Set your zone and project variables and get the credentials for the kubernetes cluster
+
+```bash
+GCP_PROJECT=my-spinnaker-project
+ZONE=us-central1-f
+K8_TEST=my-test-cluster
+GCP_TEST=my-test-project
+gcloud container clusters get-credentials $K8_TEST --zone $ZONE --project $GCP_TEST
+```
+
+## Part 2: Add Service account to GCP
+
+Create the service account in GCP test project (note that you get the service account from your Spinnaker project)
+
+````bash
+HALYARD_SA=halyard-service-account
+
+#Get the SA email from the Spinnaker project
+HALYARD_SA_EMAIL=$(gcloud iam service-accounts list \
+    --project=$GCP_PROJECT \
+    --filter="displayName:$HALYARD_SA" \
+    --format='value(email)')
+
+#Add policy bindings in the Test project
+gcloud projects add-iam-policy-binding $GCP_TEST \
+    --role roles/iam.serviceAccountKeyAdmin \
+    --member serviceAccount:$HALYARD_SA_EMAIL
+
+gcloud projects add-iam-policy-binding $GCP_TEST \
+    --role roles/container.admin \
+    --member serviceAccount:$HALYARD_SA_EMAIL
+```` 
+## Part 3: Add a service account (SA) to kubernetes
+
+Next we need to add a service account to kubernetes that will handle the authorization inside the kubernetes cluster.
+Create a file, spinnaker-service-account.yaml, with the following content:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spinnaker-service-account
+  namespace: default
+```
+Apply the service account
+
+```bash
+kubectl apply -f ./spinnaker-service-account.yaml
+```
+
+Then we need to set access for Spinnaker to edit the cluster in order to let Spinnaker manage deployments to the cluster
+
+```bash
+kubectl create clusterrolebinding \
+    --user system:serviceaccount:default:spinnaker-service-account \
+    spinnaker \
+    --clusterrole edit
+```
+    
+If you can't create a clusterrolebinding make sure that you have the right permissions.
+The following command enables you to make other roles in the cluster
+
+```bash
+#replace your.google.cloud.email@example.org with your Gcloud account
+kubectl create clusterrolebinding user-cluster-admin-binding \
+    --clusterrole=cluster-admin \
+    --user=your.google.cloud.email@example.org
+```
+      
+Now we want to get the secret for the service account that was created by kubernetes. 
+Store it somewhere safe for the next part
+
+```bash
+#Get the name of the secret
+SERVICE_ACCOUNT_TOKEN=`kubectl get serviceaccounts spinnaker-service-account -o jsonpath='{.secrets[0].name}'`
+
+#Get token and base64 decode it since all secrets are stored in base64 in kubernetes and store it somewhere safe for later use
+kubectl get secret $SERVICE_ACCOUNT_TOKEN -o jsonpath='{.data.token}' | base64 -D
+```
+
+## Part 4: Add provider to halyard
+
+SSH in to your halyard instance
+
+```bash
+gcloud compute ssh $HALYARD_HOST \
+    --project=$GCP_PROJECT \
+    --ssh-flag="-L 9000:localhost:9000" \
+    --ssh-flag="-L 8084:localhost:8084"
+```
+
+Add the credentials to the kubeconfig file
+
+```bash
+gcloud container clusters get-credentials $K8_TEST --project $GCP_TEST --zone us-central1-f
+```
+
+Get the new user profile that was created by gcloud and add the token you received before in part 3
+
+```bash
+TEST_USER_PROFILE=`kubectl config current-context`
+kubectl config set-credentials $TEST_USER_PROFILE --token replace-with-your-token-here
+```
+
+Add the new kubernetes provider
+```bash
+hal config provider kubernetes account add my-test-account \
+    --docker-registries my-gcr-account \
+    --context $(kubectl config current-context)
+```
+
+Apply your changes to Spinnaker
+
+```bash
+hal deploy apply
+```
+
+
+

--- a/setup/quickstart/halyard-gke-deploy-rbac/index.md
+++ b/setup/quickstart/halyard-gke-deploy-rbac/index.md
@@ -35,7 +35,7 @@ At the end of this guide you will have:
    gcloud info
    ```
 
-   If you are unfamiliar with how to use multiple projects with ```bash gcloud ``` you can use this [guide](https://cloud.google.com/sdk/docs/managing-configurations) to get started.
+   If you are unfamiliar with how to use multiple projects with ```gcloud``` you can use this [guide](https://cloud.google.com/sdk/docs/managing-configurations) to get started.
 
 2. Set your zone and project variables and get the credentials for the Kubernetes cluster:
 
@@ -98,7 +98,7 @@ At the end of this guide you will have:
      --clusterrole edit
    ```
     
-   If you can't create a ```bash clusterrolebinding``` make sure that you have the right permissions.
+   If you can't create a ```clusterrolebinding``` make sure that you have the right permissions.
    The following command enables you to make other roles in the cluster:
 
    ```bash
@@ -136,7 +136,7 @@ At the end of this guide you will have:
    gcloud container clusters get-credentials $K8_TEST --project $GCP_TEST --zone us-central1-f
    ```
 
-3. Get the new user profile that was created by ```bash gcloud``` and add the token you received before in part 3 step 4.
+3. Get the new user profile that was created by ```gcloud``` and add the token you received before in part 3 step 4.
 
    ```bash
    TEST_USER_PROFILE=`kubectl config current-context`
@@ -156,6 +156,4 @@ At the end of this guide you will have:
    ```bash
    hal deploy apply
    ```
-
-
 

--- a/setup/quickstart/halyard-gke-deploy-rbac/index.md
+++ b/setup/quickstart/halyard-gke-deploy-rbac/index.md
@@ -69,6 +69,7 @@ At the end of this guide you will have:
      --role roles/container.admin \
      --member serviceAccount:$HALYARD_SA_EMAIL
    ``` 
+
 ## Part 3: Add a service account (SA) to Kubernetes
 
 1. Next we need to add a service account to Kubernetes that will handle the authorization inside the Kubernetes cluster.

--- a/setup/quickstart/halyard-gke-deploy-rbac/index.md
+++ b/setup/quickstart/halyard-gke-deploy-rbac/index.md
@@ -39,122 +39,122 @@ At the end of this guide you will have:
 
 2. Set your zone and project variables and get the credentials for the Kubernetes cluster:
 
-  ```bash
-  GCP_PROJECT=my-spinnaker-project
-  ZONE=us-central1-f
-  K8_TEST=my-test-cluster
-  GCP_TEST=my-test-project
-  gcloud container clusters get-credentials $K8_TEST --zone $ZONE --project $GCP_TEST
-  ```
+   ```bash
+   GCP_PROJECT=my-spinnaker-project
+   ZONE=us-central1-f
+   K8_TEST=my-test-cluster
+   GCP_TEST=my-test-project
+   gcloud container clusters get-credentials $K8_TEST --zone $ZONE --project $GCP_TEST
+   ```
 
 ## Part 2: Add Service account to GCP
 
 1. Create the service account in the GCP test project.
 
-  ```bash
-  HALYARD_SA=halyard-service-account
+   ```bash
+   HALYARD_SA=halyard-service-account
 
-  #Get the SA email from the Spinnaker project
-  HALYARD_SA_EMAIL=$(gcloud iam service-accounts list \
-    --project=$GCP_PROJECT \
-    --filter="displayName:$HALYARD_SA" \
-    --format='value(email)')
+   #Get the SA email from the Spinnaker project
+   HALYARD_SA_EMAIL=$(gcloud iam service-accounts list \
+     --project=$GCP_PROJECT \
+     --filter="displayName:$HALYARD_SA" \
+     --format='value(email)')
 
-  #Add policy bindings in the Test project
-  gcloud projects add-iam-policy-binding $GCP_TEST \
-    --role roles/iam.serviceAccountKeyAdmin \
-    --member serviceAccount:$HALYARD_SA_EMAIL
+   #Add policy bindings in the Test project
+   gcloud projects add-iam-policy-binding $GCP_TEST \
+     --role roles/iam.serviceAccountKeyAdmin \
+     --member serviceAccount:$HALYARD_SA_EMAIL
 
-  gcloud projects add-iam-policy-binding $GCP_TEST \
-    --role roles/container.admin \
-    --member serviceAccount:$HALYARD_SA_EMAIL
-  ``` 
+   gcloud projects add-iam-policy-binding $GCP_TEST \
+     --role roles/container.admin \
+     --member serviceAccount:$HALYARD_SA_EMAIL
+   ``` 
 ## Part 3: Add a service account (SA) to Kubernetes
 
 1. Next we need to add a service account to Kubernetes that will handle the authorization inside the Kubernetes cluster.
-Create a file, spinnaker-service-account.yaml, with the following content:
+   Create a file, spinnaker-service-account.yaml, with the following content:
 
-  ```yaml
-  apiVersion: v1
-  kind: ServiceAccount
-  metadata:
-    name: spinnaker-service-account
-    namespace: default
-  ```
+   ```yaml
+   apiVersion: v1
+   kind: ServiceAccount
+   metadata:
+     name: spinnaker-service-account
+     namespace: default
+   ```
 
 2. Apply the service account
 
-  ```bash
-  kubectl apply -f ./spinnaker-service-account.yaml
-  ```
+   ```bash
+   kubectl apply -f ./spinnaker-service-account.yaml
+   ```
 
 3. Then we need to set access for Spinnaker to edit the cluster so it can manage deployments there.
 
-  ```bash
-  kubectl create clusterrolebinding \
-    --user system:serviceaccount:default:spinnaker-service-account \
-    spinnaker \
-    --clusterrole edit
-  ```
+   ```bash
+   kubectl create clusterrolebinding \
+     --user system:serviceaccount:default:spinnaker-service-account \
+     spinnaker \
+     --clusterrole edit
+   ```
     
-  If you can't create a ```bash clusterrolebinding``` make sure that you have the right permissions.
-  The following command enables you to make other roles in the cluster:
+   If you can't create a ```bash clusterrolebinding``` make sure that you have the right permissions.
+   The following command enables you to make other roles in the cluster:
 
-  ```bash
-  #replace your.google.cloud.email@example.org with your Gcloud account
-  kubectl create clusterrolebinding user-cluster-admin-binding \
-    --clusterrole=cluster-admin \
-    --user=your.google.cloud.email@example.org
-  ```
+   ```bash
+   #replace your.google.cloud.email@example.org with your Gcloud account
+   kubectl create clusterrolebinding user-cluster-admin-binding \
+     --clusterrole=cluster-admin \
+     --user=your.google.cloud.email@example.org
+   ```
       
 4. Now we want to get the secret for the service account that was created by Kubernetes. 
-  Store it somewhere safe for the next part.
+   Store it somewhere safe for the next part.
 
-  ```bash
-  #Get the name of the secret
-  SERVICE_ACCOUNT_TOKEN=`kubectl get serviceaccounts spinnaker-service-account -o jsonpath='{.secrets[0].name}'`
+   ```bash
+   #Get the name of the secret
+   SERVICE_ACCOUNT_TOKEN=`kubectl get serviceaccounts spinnaker-service-account -o jsonpath='{.secrets[0].name}'`
 
-  #Get token and base64 decode it since all secrets are stored in base64 in Kubernetes and store it somewhere safe for later use
-  kubectl get secret $SERVICE_ACCOUNT_TOKEN -o jsonpath='{.data.token}' | base64 -D
-  ```
+   #Get token and base64 decode it since all secrets are stored in base64 in Kubernetes and store it somewhere safe for later use
+   kubectl get secret $SERVICE_ACCOUNT_TOKEN -o jsonpath='{.data.token}' | base64 -D
+   ```
 
 ## Part 4: Add provider to Halyard
 
 1. SSH into your halyard instance.
 
-  ```bash
-  gcloud compute ssh $HALYARD_HOST \
-    --project=$GCP_PROJECT \
-    --ssh-flag="-L 9000:localhost:9000" \
+   ```bash
+   gcloud compute ssh $HALYARD_HOST \
+     --project=$GCP_PROJECT \
+     --ssh-flag="-L 9000:localhost:9000" \
     --ssh-flag="-L 8084:localhost:8084"
-  ```
+   ```
 
 2. Add the credentials to the kubeconfig file.
 
-  ```bash
-  gcloud container clusters get-credentials $K8_TEST --project $GCP_TEST --zone us-central1-f
-  ```
+   ```bash
+   gcloud container clusters get-credentials $K8_TEST --project $GCP_TEST --zone us-central1-f
+   ```
 
 3. Get the new user profile that was created by ```bash gcloud``` and add the token you received before in part 3 step 4.
 
-  ```bash
-  TEST_USER_PROFILE=`kubectl config current-context`
-  kubectl config set-credentials $TEST_USER_PROFILE --token replace-with-your-token-here
-  ```
+   ```bash
+   TEST_USER_PROFILE=`kubectl config current-context`
+   kubectl config set-credentials $TEST_USER_PROFILE --token replace-with-your-token-here
+   ```
 
 4. Add the new Kubernetes provider.
 
-  ```bash
-  hal config provider kubernetes account add my-test-account \
-    --docker-registries my-gcr-account \
-    --context $(kubectl config current-context)
-  ```
+   ```bash
+   hal config provider kubernetes account add my-test-account \
+     --docker-registries my-gcr-account \
+     --context $(kubectl config current-context)
+   ```
 
 5. Apply your changes to Spinnaker.
 
-  ```bash
-  hal deploy apply
-  ```
+   ```bash
+   hal deploy apply
+   ```
 
 
 

--- a/setup/quickstart/halyard-gke-deploy-rbac/index.md
+++ b/setup/quickstart/halyard-gke-deploy-rbac/index.md
@@ -7,8 +7,6 @@ sidebar:
 
 {% include toc %}
 
-# Deploy to Google Kubernetes Engine with RBAC
-
 If you've deployed Spinnaker already using [this
 codelab](/setup/quickstart/halyard-gke) you're left with a Spinnaker that can only deploy to the cluster that Spinnaker is deployed in.
 In many cases you want to deploy to clusters in another GCP project that also have Kubernetes RBAC enabled.

--- a/setup/quickstart/halyard-gke-deploy-rbac/index.md
+++ b/setup/quickstart/halyard-gke-deploy-rbac/index.md
@@ -9,36 +9,35 @@ sidebar:
 
 If you've deployed Spinnaker already using [this
 codelab](/setup/quickstart/halyard-gke) you're left with a Spinnaker that can only deploy to the cluster that Spinnaker is deployed in.
-In many cases you want to deploy to clusters in another GCP project that also have Kubernetes RBAC enabled.
+In many cases you want to deploy to clusters in another GCP project that has Kubernetes RBAC enabled.
 
-In this codelab, we will enable Spinnaker to push your containers to another GCP project that have a cluster secured by RBAC. This codelab will allow Spinnaker to be able to manipulate all deployments in the target cluster. 
-You may want to limit Spinnaker further but how to do that is not covered by this tutorial. 
-This guide won't show you how to setup Spinnaker in a RBAC cluster.
+This codelab shows how to push your containers to a separate, RBAC-enabled cluster in a different GCP project, and how to enable Spinnaker to manipulate deployments in that cluster.
+This guide doesn't show you how to setup Spinnaker in a RBAC cluster.
+You may want to limit Spinnaker further, for example only let Spinnaker edit deployments in a specific namespace, but how to do that is not covered by this tutorial.
 
 ## Overview
 
-At the end of this guide you will have
+At the end of this guide you will have:
 
 * A new Kubernetes provider with RBAC enabled
 * Ability to deploy to a cluster in another GCP project
 
 ## Part 0: Prerequisites
 
-A GCP project (referred to as $GCP_PROJECT) running a Spinnaker [GKE cluster with halyard](/setup/quickstart/halyard-gke/)
+* A GCP project (referred to as $GCP_PROJECT) running a Spinnaker [GKE cluster with halyard](/setup/quickstart/halyard-gke/)
+* Another K8s cluster (referred to as $K8_TEST) running with Kubernetes version > 1.6 on another GCP project ($GCP_TEST)
 
-Another K8s cluster (referred to as $K8_TEST) running with Kubernetes version > 1.6 on another GCP project ($GCP_TEST)
+## Part 1: Configure gcloud
 
-## Part 1: Configure Gcloud
-
-Make sure that you are authenticated against the test cluster ($K8_TEST). 
+1. Make sure that you are authenticated against the test cluster ($K8_TEST). 
 
 ```bash
 gcloud info
 ```
 
-If you are unfamiliar with how to use multiple project with gcloud you can use this [guide](https://cloud.google.com/sdk/docs/managing-configurations) to get started
+If you are unfamiliar with how to use multiple projects with ```bash gcloud ``` you can use this [guide](https://cloud.google.com/sdk/docs/managing-configurations) to get started.
 
-Set your zone and project variables and get the credentials for the kubernetes cluster
+2. Set your zone and project variables and get the credentials for the Kubernetes cluster:
 
 ```bash
 GCP_PROJECT=my-spinnaker-project
@@ -50,7 +49,7 @@ gcloud container clusters get-credentials $K8_TEST --zone $ZONE --project $GCP_T
 
 ## Part 2: Add Service account to GCP
 
-Create the service account in GCP test project (note that you get the service account from your Spinnaker project)
+1. Create the service account in the GCP test project.
 
 ````bash
 HALYARD_SA=halyard-service-account
@@ -70,9 +69,9 @@ gcloud projects add-iam-policy-binding $GCP_TEST \
     --role roles/container.admin \
     --member serviceAccount:$HALYARD_SA_EMAIL
 ```` 
-## Part 3: Add a service account (SA) to kubernetes
+## Part 3: Add a service account (SA) to Kubernetes
 
-Next we need to add a service account to kubernetes that will handle the authorization inside the kubernetes cluster.
+1. Next we need to add a service account to Kubernetes that will handle the authorization inside the Kubernetes cluster.
 Create a file, spinnaker-service-account.yaml, with the following content:
 
 ```yaml
@@ -82,13 +81,14 @@ metadata:
   name: spinnaker-service-account
   namespace: default
 ```
-Apply the service account
+
+2. Apply the service account
 
 ```bash
 kubectl apply -f ./spinnaker-service-account.yaml
 ```
 
-Then we need to set access for Spinnaker to edit the cluster in order to let Spinnaker manage deployments to the cluster
+3. Then we need to set access for Spinnaker to edit the cluster so it can manage deployments there.
 
 ```bash
 kubectl create clusterrolebinding \
@@ -97,8 +97,8 @@ kubectl create clusterrolebinding \
     --clusterrole edit
 ```
     
-If you can't create a clusterrolebinding make sure that you have the right permissions.
-The following command enables you to make other roles in the cluster
+If you can't create a ```bash clusterrolebinding``` make sure that you have the right permissions.
+The following command enables you to make other roles in the cluster:
 
 ```bash
 #replace your.google.cloud.email@example.org with your Gcloud account
@@ -107,20 +107,20 @@ kubectl create clusterrolebinding user-cluster-admin-binding \
     --user=your.google.cloud.email@example.org
 ```
       
-Now we want to get the secret for the service account that was created by kubernetes. 
-Store it somewhere safe for the next part
+4. Now we want to get the secret for the service account that was created by Kubernetes. 
+Store it somewhere safe for the next part.
 
 ```bash
 #Get the name of the secret
 SERVICE_ACCOUNT_TOKEN=`kubectl get serviceaccounts spinnaker-service-account -o jsonpath='{.secrets[0].name}'`
 
-#Get token and base64 decode it since all secrets are stored in base64 in kubernetes and store it somewhere safe for later use
+#Get token and base64 decode it since all secrets are stored in base64 in Kubernetes and store it somewhere safe for later use
 kubectl get secret $SERVICE_ACCOUNT_TOKEN -o jsonpath='{.data.token}' | base64 -D
 ```
 
-## Part 4: Add provider to halyard
+## Part 4: Add provider to Halyard
 
-SSH in to your halyard instance
+1. SSH into your halyard instance.
 
 ```bash
 gcloud compute ssh $HALYARD_HOST \
@@ -129,27 +129,28 @@ gcloud compute ssh $HALYARD_HOST \
     --ssh-flag="-L 8084:localhost:8084"
 ```
 
-Add the credentials to the kubeconfig file
+2. Add the credentials to the kubeconfig file.
 
 ```bash
 gcloud container clusters get-credentials $K8_TEST --project $GCP_TEST --zone us-central1-f
 ```
 
-Get the new user profile that was created by gcloud and add the token you received before in part 3
+3. Get the new user profile that was created by ```bash gcloud``` and add the token you received before in part 3 step 4.
 
 ```bash
 TEST_USER_PROFILE=`kubectl config current-context`
 kubectl config set-credentials $TEST_USER_PROFILE --token replace-with-your-token-here
 ```
 
-Add the new kubernetes provider
+4. Add the new Kubernetes provider.
+
 ```bash
 hal config provider kubernetes account add my-test-account \
     --docker-registries my-gcr-account \
     --context $(kubectl config current-context)
 ```
 
-Apply your changes to Spinnaker
+5. Apply your changes to Spinnaker.
 
 ```bash
 hal deploy apply

--- a/setup/quickstart/halyard.md
+++ b/setup/quickstart/halyard.md
@@ -12,4 +12,4 @@ are a few configurations to get you started. If your environment matches one of 
 * [Halyard on Google Compute Engine Quickstart](/setup/quickstart/halyard-gce/)
 * [Public Spinnaker on Google Kubernetes
   Engine](/setup/quickstart/halyard-gke-public/)
-* [Deploy to RBAC enabled cluster](/setup/quickstart/halyard-gke-deploy-rbac)
+* [Deploy to RBAC enabled cluster on Google Kubernetes Engine](/setup/quickstart/halyard-gke-deploy-rbac)

--- a/setup/quickstart/halyard.md
+++ b/setup/quickstart/halyard.md
@@ -12,3 +12,4 @@ are a few configurations to get you started. If your environment matches one of 
 * [Halyard on Google Compute Engine Quickstart](/setup/quickstart/halyard-gce/)
 * [Public Spinnaker on Google Kubernetes
   Engine](/setup/quickstart/halyard-gke-public/)
+* [Deploy to RBAC enabled cluster](/setup/quickstart/halyard-gke-deploy-rbac)


### PR DESCRIPTION
A manual to enable the Quick Full-Install Halyard Spinnaker deployment to be able to deploy images to other GCP projects with GKE that have RBAC enabled.