### PR TITLE
docs(reference): changed account in description to account name

### DIFF
--- a/reference/api/docs.html
+++ b/reference/api/docs.html
@@ -3650,7 +3650,7 @@ $(document).ready(function() {
 													var schemaWrapper = {
   "name" : "account",
   "in" : "path",
-  "description" : "account",
+  "description" : "account name",
   "required" : true,
   "type" : "string"
 };
@@ -3821,7 +3821,7 @@ $(document).ready(function() {
 													var schemaWrapper = {
   "name" : "account",
   "in" : "path",
-  "description" : "account",
+  "description" : "account name",
   "required" : true,
   "type" : "string"
 };
@@ -3959,7 +3959,7 @@ $(document).ready(function() {
 													var schemaWrapper = {
   "name" : "account",
   "in" : "path",
-  "description" : "account",
+  "description" : "account name",
   "required" : true,
   "type" : "string"
 };
@@ -6164,7 +6164,7 @@ $(document).ready(function() {
 													var schemaWrapper = {
   "name" : "account",
   "in" : "path",
-  "description" : "account",
+  "description" : "account name",
   "required" : true,
   "type" : "string"
 };


### PR DESCRIPTION
Updated all references to account in the API to clearly indicate its account name.

Some of our users were confused whether the documentation referred to account name or account id. This can clear up that confusion. 
