### PR TITLE
Change SELinux context

### DIFF
--- a/setup/storage/minio.md
+++ b/setup/storage/minio.md
@@ -32,6 +32,7 @@ Run the following commands (notice we are picking S3 as our storage type,
 because Minio implements the S3 API):
 
 # Ubuntu instalation
+
 ```bash
 echo $MINIO_SECRET_KEY | hal config storage s3 edit --endpoint $ENDPOINT \
     --access-key-id $MINIO_ACCESS_KEY \
@@ -42,7 +43,9 @@ hal config storage edit --type s3
 ```
 
 # Docker container instalation
+
 ```bash
+# The next two lines should be run inside the docker container only
 chcon -R --reference /root/.bashrc /root/.hal/
 ls -lZa /root # Make sure the SELinux context is the same for all files/folders
 

--- a/setup/storage/minio.md
+++ b/setup/storage/minio.md
@@ -31,7 +31,21 @@ reachable by Spinnaker. Record the following values:
 Run the following commands (notice we are picking S3 as our storage type,
 because Minio implements the S3 API):
 
+# Ubuntu instalation
 ```bash
+echo $MINIO_SECRET_KEY | hal config storage s3 edit --endpoint $ENDPOINT \
+    --access-key-id $MINIO_ACCESS_KEY \
+    --secret-access-key # will be read on STDIN to avoid polluting your
+                        # ~/.bash_history with a secret
+
+hal config storage edit --type s3 
+```
+
+# Docker container instalation
+```bash
+chcon -R --reference /root/.bashrc /root/.hal/
+ls -lZa /root # Make sure the SELinux context is the same for all files/folders
+
 echo $MINIO_SECRET_KEY | hal config storage s3 edit --endpoint $ENDPOINT \
     --access-key-id $MINIO_ACCESS_KEY \
     --secret-access-key # will be read on STDIN to avoid polluting your


### PR DESCRIPTION
Inside the container /root/.hal directory is a mounted volume, the context is the same from the host, without changing the context inside the container you'll get permission denied messages even with correct user, group and rwx permissions.