### PR TITLE
fix(sidebar/scss): make sidebar styling consistent

### DIFF
--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -491,13 +491,12 @@
 
 .nav__sub-title {
   display: block;
-  margin: 0.5rem 0;
-  padding: 0.5rem 0;
+  margin: 0.25rem 0;
+  padding: 0.25rem 0;
   font-family: $sans-serif-narrow;
   font-size: $type-size-6;
   font-weight: bold;
 /*  text-transform: uppercase; */
-  border-bottom: 1px solid $border-color;
 }
 
 /*

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -46,7 +46,7 @@
 
   li.collapsed {
     &.open ul {
-      padding-top: .5em;
+      padding-top: .1em;
     }
 
     &:before {


### PR DESCRIPTION
This fixes:
  1. Unaligned chevrons on the top-level collapsible sections
  2. Inconsistent spacing between collapsed top-level sections
     and sub-level sections
  3. Removes (arguably useless) underline for top-level sections

__Before__ 
![dxsdytbsqoz](https://user-images.githubusercontent.com/4874941/35000637-eb09cf90-fab2-11e7-929b-ccada83593f6.png)


__After__
![v8cnumskj8e](https://user-images.githubusercontent.com/4874941/35000649-f2d8d7e8-fab2-11e7-8ac3-d9234b3fd250.png)
