### PR TITLE
Fix typo in explanation of caching.spinnaker.io/ignore

### DIFF
--- a/reference/providers/kubernetes-v2/index.md
+++ b/reference/providers/kubernetes-v2/index.md
@@ -115,8 +115,8 @@ command](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands
 
 * `caching.spinnaker.io/ignore`
 
-  When set to `True`, this tells Spinnaker to ignore this resource. It will not
-  be cached, or show up in the Spinnaker UI. 
+  When set to `true`, this tells Spinnaker to ignore this resource. It will not
+  be cached, or show up in the Spinnaker UI.
 
 # How Kubernetes Resources Are Managed by Spinnaker
 


### PR DESCRIPTION
Using the value `True` causes an exception:

java.lang.IllegalArgumentException: Illegally annotated resource for 'caching.spinnaker.io/ignore': com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'True': was expecting ('true', 'false' or 'null')
 at [Source: True; line: 1, column: 9]
 at com.netflix.spinnaker.clouddriver.kubernetes.v2.description.manifest.KubernetesManifestAnnotater.getAnnotation(KubernetesManifestAnnotater.java:83) ~[clouddriver-kubernetes-1.751.0-SNAPSHOT.jar:1.751.0-SNAPSHOT]