### PR TITLE
fix(sidebar/styling): make nested spacing more consistent

### DIFF
--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -449,8 +449,11 @@
     }
   }
 
-  .nav__items-nested li {
-    font-size: $type-size-5;
+  .nav__items-nested {
+    padding-top: 1em;
+    li {
+      font-size: $type-size-5;
+    }
   }
 
   @include breakpoint(max-width ($large - 1px)) {

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -45,7 +45,7 @@
   }
 
   li.collapsed {
-    &.open ul {
+    &.open {
       padding-top: .1em;
     }
 


### PR DESCRIPTION
The spacing on the sidebar for nested subsections felt cramped. Look at the space below "Triggering Pipelines" here:

## Before

![before](https://user-images.githubusercontent.com/4874941/35770058-ca00e854-08e2-11e8-97d2-4ca671143848.png)


## After

![after](https://user-images.githubusercontent.com/4874941/35770059-cf0dca10-08e2-11e8-8bcf-74f803387ef3.png)
