### PR TITLE
fix(nav): architecture heading links to overview

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -264,7 +264,6 @@ reference:
       - title: Component Sizing
         url: /reference/halyard/component-sizing
   - title: Architecture
-    url: /reference/architecture/
     children:
       - title: Overview
         url: /reference/architecture/


### PR DESCRIPTION
![f4szxhbflcd](https://user-images.githubusercontent.com/4874941/35860445-0beb13d0-0b12-11e8-90a7-f8d6c48c1298.png)

Usually those headings don't link at all