### PR TITLE
chore(nav): move code of conduct higher in nav

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -286,12 +286,12 @@ community:
     children:
       - title: Overview
         url: /community/contributing/
+      - title: Code Of Conduct
+        url: /community/contributing/code-of-conduct/
       - title: Submitting A Patch
         url: /community/contributing/submitting/
       - title: Releasing a Patch
         url: /community/contributing/releasing/
-      - title: Code Of Conduct
-        url: /community/contributing/code-of-conduct/
       - title: Code Conventions for Server-side Components
         url: /community/contributing/back-end-code/
   - title: Publications


### PR DESCRIPTION
Right now it's hidden between a few different "patching" links which seems to dimish its importance