### PR TITLE
Adding missing reference to v3_req section

### DIFF
--- a/setup/security/authentication/x509/index.md
+++ b/setup/security/authentication/x509/index.md
@@ -58,6 +58,7 @@ Encoding with any another OID can be done by editing the openssl.conf.
     #default_keyfile 	= privkey.pem
     distinguished_name	= req_distinguished_name
     attributes		= req_attributes
+    req_extensions = v3_req
 
     [ req_distinguished_name ]
     countryName			= Country Name (2 letter code)


### PR DESCRIPTION
openssl.conf didn't actually tell OpenSSL to include the OID for group membership