### PR TITLE
Update GKE Quickstart to download latest kubectl

### DIFF
--- a/setup/quickstart/halyard-gke/index.md
+++ b/setup/quickstart/halyard-gke/index.md
@@ -141,7 +141,7 @@ gcloud compute ssh $HALYARD_HOST \
 ### Install kubectl
 
 ```bash
-curl -O https://storage.googleapis.com/kubernetes-release/release/v1.6.1/bin/linux/amd64/kubectl
+curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
 
 chmod +x kubectl
 


### PR DESCRIPTION
Ran into an issue with the halyard Quickstart for GKE docs where I was unable to deploy:
```
! ERROR Could not parse connection information from:
()

- Failed to deploy Spinnaker.
```

Turns out it was due to an older client version of kubectl. When I went back to see how the quickstart guide suggested I install kubectl, i noticed the docs have it hardcoded to 1.6.1. Updating docs so that recommendation is to install latest stable, as recommended on the kubectl install page.