### PR TITLE
Fix long line in GKE Quickstart

### DIFF
--- a/setup/quickstart/halyard-gke/index.md
+++ b/setup/quickstart/halyard-gke/index.md
@@ -141,7 +141,9 @@ gcloud compute ssh $HALYARD_HOST \
 ### Install kubectl
 
 ```bash
-curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+KUBECTL_LATEST=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+
+curl -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_LATEST/bin/linux/amd64/kubectl
 
 chmod +x kubectl
 


### PR DESCRIPTION
Extra long line from #580 looks terrible in docs page (https://www.spinnaker.io/setup/quickstart/halyard-gke/). Oops!