### PR TITLE
fix(gcr): fix required catalog roles

### DIFF
--- a/setup/install/providers/docker-registry.md
+++ b/setup/install/providers/docker-registry.md
@@ -107,7 +107,12 @@ SA_EMAIL=$(gcloud iam service-accounts list \
 PROJECT=$(gcloud info --format='value(config.project)')
 
 gcloud projects add-iam-policy-binding $PROJECT \
-    --role roles/storage.admin --member serviceAccount:$SA_EMAIL
+    --member serviceAccount:$SA_EMAIL \
+    --role roles/browser
+
+gcloud projects add-iam-policy-binding $PROJECT \
+    --member serviceAccount:$SA_EMAIL \
+    --role roles/storage.admin
 
 mkdir -p $(dirname $SERVICE_ACCOUNT_DEST)
 

--- a/setup/quickstart/halyard-gke/index.md
+++ b/setup/quickstart/halyard-gke/index.md
@@ -99,6 +99,10 @@ GCS_SA_EMAIL=$(gcloud iam service-accounts list \
 gcloud projects add-iam-policy-binding $GCP_PROJECT \
     --role roles/storage.admin \
     --member serviceAccount:$GCS_SA_EMAIL
+
+gcloud projects add-iam-policy-binding $PROJECT \
+    --member serviceAccount:$GCS_SA_EMAIL \
+    --role roles/browser
 ```
 
 ### Create halyard host VM


### PR DESCRIPTION
Thanks to @wheleph for finding this: https://stackoverflow.com/questions/44783736/how-to-list-images-and-tags-from-the-gcr-io-docker-registry-using-the-http-api/45097445#45097445 fix. 

Closes https://github.com/spinnaker/spinnaker/issues/2407

@duftler can you verify this works for you? My project/images may be too old