### PR TITLE
fix(codelabs): Minor clarifying updates to kubernetes v2 codelab

### DIFF
--- a/guides/tutorials/codelabs/kubernetes-v2-source-to-prod/index.md
+++ b/guides/tutorials/codelabs/kubernetes-v2-source-to-prod/index.md
@@ -33,11 +33,11 @@ Before we begin, we need to do the following:
 
 * [Configure Kubernetes](#configure-kubernetes)
 
-  Two Kubernetes clusters, one for staging, and one for prod.
+  Two Kubernetes clusters, one for staging and one for prod.
 
 * [Configure Spinnaker](#configure-spinnaker)
   
-  A running Spinnaker instance, able to deploy to Kubernetes, and download
+  A running Spinnaker instance, able to deploy to Kubernetes and download
   artifacts from GitHub.
 
 * [Configure Webhooks](#configure-webhooks)
@@ -196,12 +196,13 @@ NAME        TYPE       CLUSTER-IP    EXTERNAL-IP   PORT(S)          AGE
 spin-gate   NodePort   10.7.255.85   <none>        8084:31355/TCP   32m
 ```
 
-At this point, you will (for this codelab only) have to open your firewalls on a node
-(with IP `$NODE_IP`) in that cluster to all addresses on for TCP connections on
-`$NODE_PORT`. If (for a production use-case) you were running Spinnaker with
-[authentication](/setup/security), only webhooks would be allowed, which you
-can reject by header or payload. See [the webhook guide for more 
-details](/guides/user/triggers/webhooks).
+Now pick any node in the cluster and record its IP as `$NODE_IP`; for the purposes of
+this codelab, we'll be sending external webhooks to `$NODE_PORT` on that node.  In
+order for these webhooks to work, you will (for this codelab only) have to open your
+firewall on that node to all addresses for TCP connections on `$NODE_PORT`. If
+(for a production use-case) you were running Spinnaker with [authentication](/setup/security),
+only webhooks would be allowed, which you can reject by header or payload.
+See [the webhook guide for more details](/guides/user/triggers/webhooks).
 
 ### Allow Docker to Post Build Events
 
@@ -331,9 +332,9 @@ Save the pipeline.
 
 # 3. Deploy Manifests to Staging
 
-Trigger the pipeline by pushing a commit to your repository. The pipeline
-should start in a few seconds -- when it completes, click __Details__ to see
-information about the execution:
+Trigger the pipeline by pushing a commit to the `manifests/demo.yml` file in
+your repository. The pipeline should start in a few seconds -- when it completes,
+click __Details__ to see information about the execution:
 
 {% include figure
    image_path="./staging-execution.png"
@@ -341,7 +342,7 @@ information about the execution:
 
 There are a couple of things to notice here: 
 
-* In the top right we get details about the commit that triggered this
+* In the top left we get details about the commit that triggered this
   pipeline. 
 
 * In the __Deploy Status__ we can see what the YAML was that Spinnaker
@@ -496,7 +497,7 @@ trigger that depends on the "Validate Staging" pipeline:
 %}
 
 Next, change the __Account__ the "Deploy (Manifest)" stage deploys to
-point at __demo-prod__:
+point at __prod-demo__:
 
 {% include figure
    image_path="./deploy-to-prod-account.png"

--- a/guides/tutorials/codelabs/kubernetes-v2-source-to-prod/index.md
+++ b/guides/tutorials/codelabs/kubernetes-v2-source-to-prod/index.md
@@ -197,10 +197,10 @@ spin-gate   NodePort   10.7.255.85   <none>        8084:31355/TCP   32m
 ```
 
 Now pick any node in the cluster and record its IP as `$NODE_IP`; for the purposes of
-this codelab, we'll be sending external webhooks to `$NODE_PORT` on that node.  In
-order for these webhooks to work, you will (for this codelab only) have to open your
-firewall on that node to all addresses for TCP connections on `$NODE_PORT`. If
-(for a production use-case) you were running Spinnaker with [authentication](/setup/security),
+this codelab, we'll be sending external webhooks to `$NODE_PORT` on that node. In
+order for these webhooks to work, for this codelab only, open your firewall
+on that node to all addresses for TCP connections on `$NODE_PORT`. If you
+were running Spinnaker in production with [authentication](/setup/security),
 only webhooks would be allowed, which you can reject by header or payload.
 See [the webhook guide for more details](/guides/user/triggers/webhooks).
 
@@ -333,7 +333,7 @@ Save the pipeline.
 # 3. Deploy Manifests to Staging
 
 Trigger the pipeline by pushing a commit to the `manifests/demo.yml` file in
-your repository. The pipeline should start in a few seconds -- when it completes,
+your repository. The pipeline should start in a few seconds. When it completes,
 click __Details__ to see information about the execution:
 
 {% include figure


### PR DESCRIPTION
* Removed two extraneous commas
* Clarified that users pick a random node from the pool to use for webhooks
* Clarified that the first git push in the codelab must edit the manifest file
* Fixed location of commit details (they're on the right, not the left)
* Fixed reference to prod account to be consistent with set-up above