### PR TITLE
fix(gke/install): fix endpoint for cloud shell

### DIFF
--- a/downloads/kubernetes/quick-install.yml
+++ b/downloads/kubernetes/quick-install.yml
@@ -230,7 +230,7 @@ data:
         apiSecurity:
           ssl:
             enabled: false
-          overrideBaseUrl: http://localhost:9000/gate
+          overrideBaseUrl: /gate
         uiSecurity:
           ssl:
             enabled: false


### PR DESCRIPTION
The localhost baseurl breaks when in cloudshell (doesn't forward to
localhost)