### PR TITLE
Makes the feedback contents include a link to the page, instead of ju…

### DIFF
--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -47,7 +47,7 @@ layout: has_masthead
           <a href="https://github.com/spinnaker/spinnaker/issues/new" target="_blank">File a bug</a>
         </div>
         <div class="feedback">
-          <a href="https://github.com/spinnaker/spinnaker.github.io/issues/new?body=Page:+{{page.url}}%0A%0AFeedback:" target="_blank">Comment on this document</a>
+          <a href="https://github.com/spinnaker/spinnaker.github.io/issues/new?body=Page:+[{{page.url}}]({{site.url}}{{page.url}})%0A%0AFeedback:" target="_blank">Comment on this document</a>
         </div>
 
         {% if page.modified %}


### PR DESCRIPTION
…st the text of the path.

![pmw93pec6v8](https://user-images.githubusercontent.com/13141550/38324740-26191764-380f-11e8-951b-f5facae1845f.png)
