### PR TITLE
Rename "Discourse" to "Community Forum" in footer.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,7 @@
       <li><a href="http://github.com/{{ site.author.github }}">GitHub</a></li> &nbsp;&nbsp;|
     {% endif %}
     {% if site.discourse.url %}
-      <li><a href="https://{{ site.discourse.url }}">Discourse</a></li> &nbsp;&nbsp;|
+      <li><a href="https://{{ site.discourse.url }}">Community Forum</a></li> &nbsp;&nbsp;|
     {% endif %}
     {% if site.slack.url %}
       <li><a href="http://{{ site.slack.url }}">Slack</a></li> &nbsp;&nbsp;|


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker.github.io/issues/654