### PR TITLE
Add link to whitelisted java methods that can be used in SpEL

### DIFF
--- a/guides/user/pipeline-expressions/index.md
+++ b/guides/user/pipeline-expressions/index.md
@@ -249,7 +249,7 @@ You can also declare new classes. Note that package names need to be fully quali
 
 To call static methods, use this syntax `T(fully.qualified.class.name).methodName()`. For example, to calculate the date 5 days from now, you can call: `${ T(java.time.LocalDate).now().plusDays(5).toString() }`
 
-Whitelisted java methods can be found [here](https://github.com/spinnaker/orca/blob/master/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/whitelisting/InstantiationTypeRestrictor.java#L27).
+Whitelisted java methods can be found [here](https://github.com/spinnaker/orca/blob/6d0ba0bf8af5e06c5b405b8294f07e7a5a4c335a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/whitelisting/InstantiationTypeRestrictor.java#L26).
 
 ### Some useful things to know
 

--- a/guides/user/pipeline-expressions/index.md
+++ b/guides/user/pipeline-expressions/index.md
@@ -247,6 +247,8 @@ You can use methods available to existing types like String - `${ 'this is a lon
 
 You can also declare new classes. Note that package names need to be fully qualified. In the following expression, we're getting the current date as MM-dd-yyyy format: `${ new java.text.SimpleDateFormat('MM-dd-yyyy').format(new java.util.Date()) }`
 
+To call static methods, use this syntax `T(fully.qualified.class.name).methodName()`. For example, to calculate the date 5 days from now, you can call: `${ T(java.time.LocalDate).now().plusDays(5).toString() }`
+
 Whitelisted java methods can be found [here](https://github.com/spinnaker/orca/blob/fc87a8e99ec59a4e129646026987aa5adbde2d31/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/whitelisting/InstantiationTypeRestrictor.java#L25).
 
 ### Some useful things to know

--- a/guides/user/pipeline-expressions/index.md
+++ b/guides/user/pipeline-expressions/index.md
@@ -249,7 +249,7 @@ You can also declare new classes. Note that package names need to be fully quali
 
 To call static methods, use this syntax `T(fully.qualified.class.name).methodName()`. For example, to calculate the date 5 days from now, you can call: `${ T(java.time.LocalDate).now().plusDays(5).toString() }`
 
-Whitelisted java methods can be found [here](https://github.com/spinnaker/orca/blob/fc87a8e99ec59a4e129646026987aa5adbde2d31/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/whitelisting/InstantiationTypeRestrictor.java#L25).
+Whitelisted java methods can be found [here](https://github.com/spinnaker/orca/blob/master/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/whitelisting/InstantiationTypeRestrictor.java#L27).
 
 ### Some useful things to know
 

--- a/guides/user/pipeline-expressions/index.md
+++ b/guides/user/pipeline-expressions/index.md
@@ -245,7 +245,9 @@ You can execute java code within the expression language. This can be useful for
 
 You can use methods available to existing types like String - `${ 'this is a long string'.substring(0,5)}`
 
-You can also declare new classes. Note that package names need to be fully qualified. In the following expression, we're getting the current date as MM-dd-yyyy format: `${ new java.text.SimpleDateFormat('MM-dd-yyyy').format(new java.util.Date()) }` 
+You can also declare new classes. Note that package names need to be fully qualified. In the following expression, we're getting the current date as MM-dd-yyyy format: `${ new java.text.SimpleDateFormat('MM-dd-yyyy').format(new java.util.Date()) }`
+
+Whitelisted java methods can be found [here](https://github.com/spinnaker/orca/blob/master/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/whitelisting/InstantiationTypeRestrictor.java#L26).
 
 ### Some useful things to know
 

--- a/guides/user/pipeline-expressions/index.md
+++ b/guides/user/pipeline-expressions/index.md
@@ -247,7 +247,7 @@ You can use methods available to existing types like String - `${ 'this is a lon
 
 You can also declare new classes. Note that package names need to be fully qualified. In the following expression, we're getting the current date as MM-dd-yyyy format: `${ new java.text.SimpleDateFormat('MM-dd-yyyy').format(new java.util.Date()) }`
 
-Whitelisted java methods can be found [here](https://github.com/spinnaker/orca/blob/master/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/whitelisting/InstantiationTypeRestrictor.java#L26).
+Whitelisted java methods can be found [here](https://github.com/spinnaker/orca/blob/fc87a8e99ec59a4e129646026987aa5adbde2d31/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/expressions/whitelisting/InstantiationTypeRestrictor.java#L25).
 
 ### Some useful things to know
 


### PR DESCRIPTION
The Spinnaker SpEL documentation around java is missing an explanation that not any java method can be run using SpEL, only whitelisted methods. 

This adds this explanation + link to the code with the whitelisted methods.

@tomaslin 