### PR TITLE
x509/index.md

### DIFF
--- a/setup/security/authentication/x509/index.md
+++ b/setup/security/authentication/x509/index.md
@@ -22,7 +22,7 @@ authority**
     openssl genrsa -des3 -out client.key 4096
     ```
 
-1. Generate a certificate signing request for the server.
+1. Generate a certificate signing request for the server. Ensure the `Common Name` is set to a non-empty value.
     ```
     openssl req -new -key client.key -out client.csr
     ```


### PR DESCRIPTION
Add explicit note to ensure a "Common Name" is set.
Not setting one results in an auth failure which is not easy to debug.

Once the apiPort is configured; 
```
default:
  apiPort: 8085
```

The actual resultant error is discovered

```
{"error":"Internal Server Error","exception":"org.springframework.security.authentication.BadCredentialsException","message":"No matching pattern was found in subjectDN: O=Internet Widgits Pty Ltd, ST=Some-State, C=AU","status":500,"timestamp":1524241246779}
```

Until then the error returned is not sufficient to determine the root cause.