### PR TITLE
Fix escaping of {{ and }}

### DIFF
--- a/guides/user/kubernetes-v2/annotations-ui/index.md
+++ b/guides/user/kubernetes-v2/annotations-ui/index.md
@@ -21,7 +21,7 @@ panel for a pod:
 
 ```bash
 kubectl annotate pod my-prod-pod-v000 \
-  pod-info.details.html.spinnaker.io="<a href='https://internal-elk.net/{{ name }}'>Internal Logs Service</a>"
+  pod-info.details.html.spinnaker.io="<a href='https://internal-elk.net/{{"{{ name "}}}}'>Internal Logs Service</a>"
 ```
 
 Here's how this annotation will render in Spinnaker's UI:
@@ -41,8 +41,8 @@ with spaces and the section title is rendered using Title Case.
 pod-info.details.**html**.spinnaker.io.  Excluding "html" here would have rendered
 the link as plain text.
 3. The HTML content is taken from the annotation's value:
-`<a href='https://internal-elk.net/{{ name }}'>Internal Logs Service</a>`
-4. The pod's name will be interpolated into the link. Notice the `{{ name }}` template
+`<a href='https://internal-elk.net/{{"{{ name "}}}}'>Internal Logs Service</a>`
+4. The pod's name will be interpolated into the link. Notice the `{{"{{ name "}}}}` template
 value in the href attribute.  The full set of available values are listed at the end
 of this document.
 
@@ -72,7 +72,7 @@ a single section title.
 
 Template values can be included in the content of the annotation and will be replaced when
 they are rendered by Deck.  A templated value has the following appearance in an annotation:
-`{{ templateKey }}` where `templateKey` will vary depending on the available set of keys
+`{{"{{ templateKey "}}}}` where `templateKey` will vary depending on the available set of keys
 for the resource that is annotated.  The complete set of available keys is documented below.
 
 #### Instances

--- a/guides/user/triggers/pubsub/index.md
+++ b/guides/user/triggers/pubsub/index.md
@@ -148,7 +148,7 @@ message payload to the Spinnaker artifact format:
 [
   {
     "type": "gcs/object", # static type.
-    "reference": "{{ location }}", # 'location' in the pub/sub payload.
+    "reference": "{{"{{ location "}}}}", # 'location' in the pub/sub payload.
   }
 ]
 ```

--- a/reference/halyard/commands.md
+++ b/reference/halyard/commands.md
@@ -2851,9 +2851,9 @@ Example: "user/spinnaker" or "role/spinnakerManaged"
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--discovery`: The endpoint your Eureka discovery system is reachable at. See https://github.com/Netflix/eureka for more information.
 
-Example: http://{{region}}.eureka.url.to.use:8080/eureka-server/v2 
+Example: http://{{"{{region"}}}}.eureka.url.to.use:8080/eureka-server/v2 
 
-Using {{region}} will make Spinnaker use AWS regions in the hostname to access discovery so that you can have discovery for multiple regions.
+Using {{"{{region"}}}} will make Spinnaker use AWS regions in the hostname to access discovery so that you can have discovery for multiple regions.
  * `--edda`: The endpoint Edda is reachable at. Edda is not a hard dependency of Spinnaker, but is helpful for reducing the request volume against AWS. See https://github.com/Netflix/edda for more information.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
@@ -2899,9 +2899,9 @@ Example: "user/spinnaker" or "role/spinnakerManaged"
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--discovery`: The endpoint your Eureka discovery system is reachable at. See https://github.com/Netflix/eureka for more information.
 
-Example: http://{{region}}.eureka.url.to.use:8080/eureka-server/v2 
+Example: http://{{"{{region"}}}}.eureka.url.to.use:8080/eureka-server/v2 
 
-Using {{region}} will make Spinnaker use AWS regions in the hostname to access discovery so that you can have discovery for multiple regions.
+Using {{"{{region"}}}} will make Spinnaker use AWS regions in the hostname to access discovery so that you can have discovery for multiple regions.
  * `--edda`: The endpoint Edda is reachable at. Edda is not a hard dependency of Spinnaker, but is helpful for reducing the request volume against AWS. See https://github.com/Netflix/edda for more information.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.


### PR DESCRIPTION
Jekyll escaping was {{ is missing on some pages, so text such as `{{ name }}` would be hidden on spinnaker.io.  Fixed #773 