### PR TITLE
fix(navigation): Add nav link to pubsub (fixes #775)

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -197,7 +197,9 @@ guides:
       - title: Triggering Pipelines
         collapsed: true
         children:
-          - title: Trigging on Webhooks
+          - title: Triggering on Pub/Sub Messages
+            url: /guides/user/triggers/pubsub/
+          - title: Triggering on Webhooks
             url: /guides/user/triggers/webhooks/
           - title: Receiving Artifacts From GCS
             url: /guides/user/triggers/gcs/


### PR DESCRIPTION
Added missing link to Missing navigation link to [Triggering on Pub/Sub Messages](https://www.spinnaker.io/guides/user/triggers/pubsub/) (#775)

Also corrected the nav label for the link to <https://www.spinnaker.io/guides/user/triggers/webhooks/> now 'Triggering' instead of 'Trigging'