### PR TITLE
docs(readme) Dockerfile that allows page regeneration to be locally tested

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Ignore all files to start with, and then override
+*
+!Gemfile*
+!*.gemspec

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Dockerfile to run Jekyll locally and test the generated site
+# You must mount $(pwd) to /code (this allows pages to be dynamically regenerated without having to rebuild the Dockerfile)
+FROM ruby:2.4.1
+RUN apt-get install -y git bzip2 libssl-dev libreadline-dev zlib1g-dev
+RUN gem install bundler
+
+# bundle install from a different directory to the /code mount for a large performance increase (at least on Docker-for-Mac)
+COPY Gemfile* /install/
+COPY *.gemspec /install/
+WORKDIR /install
+RUN bundle install --frozen
+
+EXPOSE 4000
+WORKDIR /code
+ENTRYPOINT [ "bundle", "exec", "jekyll", "serve", "--host", "0.0.0.0", "--watch" ]

--- a/README.md
+++ b/README.md
@@ -30,8 +30,15 @@ Swap out `rbenv` below for `rvm` if you prefer. RVM was giving me installation i
     1. `bundle exec jekyll serve --watch --incremental`
 1. Navigate to [http://localhost:4000](http://localhost:4000) to see your locally generated page.    
 
+You can do the same within Docker using the included Dockerfile (the volume mount will still allow changes to files to be visible to Jekyll):
 
-### Page Generation
+```sh
+docker build --tag spinnaker/spinnaker.github.io-test .
+docker run -it --rm --mount "type=bind,source=$(pwd),target=/code" \
+    -p 4000:4000 spinnaker/spinnaker.github.io-test --incremental
+```
+
+## Page Generation
 
 A page named `foo.md` will be transformed to `foo/index.html` and links to `foo` will result in an HTTP 301 
 to `foo/`. This has two implications:


### PR DESCRIPTION
Added a Dockerfile that allows you to test changes by running Jekyll within a Docker container instead of installing and running it directly onto your development machine (mounting the repository code as a volume so that changes can still be reflected on the running server without rebuilding the whole image).

Instructions to use (as described in README.md):

```sh
docker build --tag spinnaker/spinnaker.github.io-test .
docker run -it --rm --mount "type=bind,source=$(pwd),target=/code" \
    -p 4000:4000 spinnaker/spinnaker.github.io-test --incremental
```

I'm not sure whether this is something that you would want, but I found it useful when testing some small typo fixes today!  I prefer running such things within Docker if possible.

Note that building the Docker image and running it both log an error to the console, but it seems harmless and I'm not sure how to avoid it:

```
fatal: Not a git repository (or any of the parent directories): .git
```