### PR TITLE
docs(halyard-gke-deploy-rbac): Fix base64 option

### DIFF
--- a/setup/quickstart/halyard-gke-deploy-rbac/index.md
+++ b/setup/quickstart/halyard-gke-deploy-rbac/index.md
@@ -116,7 +116,7 @@ At the end of this guide you will have:
    SERVICE_ACCOUNT_TOKEN=`kubectl get serviceaccounts spinnaker-service-account -o jsonpath='{.secrets[0].name}'`
 
    #Get token and base64 decode it since all secrets are stored in base64 in Kubernetes and store it somewhere safe for later use
-   kubectl get secret $SERVICE_ACCOUNT_TOKEN -o jsonpath='{.data.token}' | base64 -D
+   kubectl get secret $SERVICE_ACCOUNT_TOKEN -o jsonpath='{.data.token}' | base64 --decode
    ```
 
 ## Part 4: Add provider to Halyard


### PR DESCRIPTION
`base64 -D` didn't work well as follow.

```
$ kubectl get secret $SERVICE_ACCOUNT_TOKEN -o jsonpath='{.data.token}' | base64 -D
base64: invalid option -- 'D'
Try 'base64 --help' for more information.
```

option `-D` worked on Mac, but it did not work on Linux because it is` -d` on Linux.
This PR has changed to option `--decode` which works on both MacOS and Linux.