### PR TITLE
Fix incosistent numbering in the install proceedure

### DIFF
--- a/setup/install/index.md
+++ b/setup/install/index.md
@@ -14,8 +14,8 @@ in [Quickstart](/setup/quickstart/) might be a better choice.
 
 Installing a complete Spinnaker involves these steps:
 1. [Install Halyard](/setup/install/halyard/)
-2. [Choose an environment](/setup/install/environment/)
-3. [Choose a cloud provider](/setup/install/providers/)
+2. [Choose a cloud provider](/setup/install/providers/)
+3. [Choose an environment](/setup/install/environment/)
 4. [Deploy Spinnaker](/setup/install/deploy/)
 
 


### PR DESCRIPTION
On the [install page](https://www.spinnaker.io/setup/install/), "Choose an environment" is 2.
However, [the environment page](https://www.spinnaker.io/setup/install/environment/) shows it as 3.
Likewise, "Choose Cloud Providers" is 3 on the [install page](https://www.spinnaker.io/setup/install/), but [the providers page](https://www.spinnaker.io/setup/install/providers/) shows 2.

This PR makes the numbering consistent.
