### PR TITLE
feat(provider/kubernetes): redirect from v1 docs

### DIFF
--- a/reference/providers/kubernetes.md
+++ b/reference/providers/kubernetes.md
@@ -3,6 +3,7 @@ layout: single
 title:  "Kubernetes"
 sidebar:
   nav: reference
+redirect_from: /reference/providers/kubernetes-v1/
 ---
 
 {% include toc %}

--- a/setup/install/providers/kubernetes.md
+++ b/setup/install/providers/kubernetes.md
@@ -3,7 +3,9 @@ layout: single
 title:  "Kubernetes (legacy provider)"
 sidebar:
   nav: setup
-redirect_from: /setup/providers/kubernetes/
+redirect_from: 
+ - /setup/providers/kubernetes/
+ - /setup/install/providers/kubernetes-v1/
 ---
 
 {% include toc %}


### PR DESCRIPTION
I've made this mistake a few times when trying to guess a link