### PR TITLE
Added command to enable http artifact support

### DIFF
--- a/setup/artifacts/http.md
+++ b/setup/artifacts/http.md
@@ -33,6 +33,7 @@ configuration is needed, Spinnaker will automatically add a
 
    ```bash
    hal config features edit --artifacts true
+   hal config artifact http enable
    ```
 
 3. Add an artifact account:


### PR DESCRIPTION
When setting up an http artifact account I discovered that the documentation was lacking a command to enable http artifacts.