### PR TITLE
Include "apps" apiGroup in example RBAC role

### DIFF
--- a/setup/install/providers/kubernetes.md
+++ b/setup/install/providers/kubernetes.md
@@ -138,7 +138,7 @@ rules:
 - apiGroups: ["apps"]
   resources: ["controllerrevisions", "statefulsets"]
   verbs: ["list"]
-- apiGroups: ["extensions", "app"]
+- apiGroups: ["extensions", "app", "apps"]
   resources: ["deployments", "replicasets", "ingresses", "daemonsets"]
   verbs: ["*"]
 ---


### PR DESCRIPTION
Upgrade to Spinnaker 1.8.5 is causing replicasets requests to Kubernetes to use the "apps" apiGroup instead of "app".  This change grants access to this, while maintaining access to the "app" apiGroup for users of previous versions of Spinnaker.