### PR TITLE
docs(gcb): Adds provisional instructions for trigging pipelines on Go…

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -142,10 +142,12 @@ setup:
         children:
           - title: Set Up Continuous Integration
             url: /setup/ci/
-          - title: Travis CI
-            url: /setup/ci/travis/
+          - title: Google Cloud Build
+            url: /setup/ci/gcb/
           - title: Jenkins
             url: /setup/ci/jenkins/
+          - title: Travis CI
+            url: /setup/ci/travis/
           - title: Wercker
             url: /setup/ci/wercker/
       - title: Enable Monitoring

--- a/setup/ci/gcb.md
+++ b/setup/ci/gcb.md
@@ -1,0 +1,71 @@
+---
+layout: single
+title:  "Google Cloud Build"
+sidebar:
+  nav: setup
+---
+
+{% include toc %}
+
+Setting up [Google Cloud Build](https://cloud.google.com/cloud-build/) as a Continuous Integration (CI)
+system within Spinnaker enables triggering pipelines when builds complete.
+
+## Prerequisites
+
+You need to have a [Google Cloud Platform](https://cloud.google.com) project with the
+[Cloud Build API](http://console.cloud.google.com/apis/library/cloudbuild.googleapis.com) enabled.
+You can enable the API with the following `gcloud` command:
+
+```
+gcloud services enable cloudbuild.googleapis.com
+```
+
+## Configure Spinnaker to Listen for Google Cloud Build Pub/Sub Notifications
+
+Google Cloud Build sends [Build Notifications](https://cloud.google.com/cloud-build/docs/send-build-notifications)
+when the state of your build changes. You can create a pipeline trigger to invoke a pipeline based
+on the status of your build.
+
+1. Create a Subscription object for the `cloud-builds` topic in your project:
+
+    ```
+    PROJECT_ID=
+    SUBSCRIPTION_NAME=googleCloudBuilds
+
+    gcloud pubsub subscriptions create $SUBSCRIPTION_NAME \
+      --topic projects/$PROJECT_ID/topics/cloud-builds \
+      --project $PROJECT_ID
+    ```
+
+2. Configure and deploy Spinnaker via Halyard with your newly created subscription.
+
+    ```
+    hal config pubsub google subscription add $SUBSCRIPTION_NAME \
+      --project $PROJECT_ID \
+      --subscription-name $SUBSCRIPTION_NAME \
+      --message-format GCB
+
+    hal config pubsub google enable
+
+    hal deploy apply
+    ```
+
+## Configure Your Pipeline Trigger
+
+1. In your Pipeline configuration, click the **Configuration** stage on the far left of the pipeline diagram.
+
+2. Click **Automated Triggers**.
+
+3. In the **Type** field, select `Pub/Sub`.
+
+4. In the **Pub/Sub System Type** field, select `google`.
+
+5. In the **Subscription Name** field, select your `$SUBSCRIPTION_NAME` value.
+
+6. In the **Attribute Constraints** field, enter `status` in the **Key**, and `SUCCESS` (all upper case) in the **Value** field.
+
+7. In the **Payload Constraints** field, you can enter any of the top-level fields from the
+[Build object documentation](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#resource-build)
+as the key, and a Java regular expression as the value. For example, to match on an image produced,
+you can use the key `images` and the value `gcr\.io/my-project-id/my-application:latest` (replacing
+`my-project-id` and `my-application` with appropriate values).

--- a/setup/ci/index.md
+++ b/setup/ci/index.md
@@ -22,6 +22,7 @@ independently of one-another, enumerated below.
 
 These are the CI systems currently supported by Spinnaker:
 
+* [Google Cloud Build](/setup/ci/gcb/)
 * [Jenkins](/setup/ci/jenkins/)
 * [Travis CI](/setup/ci/travis/)
 * [Wercker](/setup/ci/wercker/)


### PR DESCRIPTION
…ogle Cloud Build builds.

We obviously need to make this **way** easier, but here's how one could do pipeline triggers from GCB using GCB's pubsub topic.

cc @duftler @skim1420 

Rendered Preview: 
![5xeepvcq3fx](https://user-images.githubusercontent.com/13141550/44170603-dba6f480-a0a5-11e8-97f5-5df3c80937d2.png)
