### PR TITLE
Update quick-install.yml for Kubernetes to use 1.9.0

### DIFF
--- a/downloads/kubernetes/quick-install.yml
+++ b/downloads/kubernetes/quick-install.yml
@@ -151,7 +151,7 @@ data:
     currentDeployment: default
     deploymentConfigurations:
     - name: default
-      version: 1.8.1
+      version: 1.9.0
       providers:
         appengine:
           enabled: false


### PR DESCRIPTION
Note: this is needed for the upcoming Kayenta tutorial on cloud.google.com (see spinnaker/spinnaker#3205).