### PR TITLE
Correct the proxied service URL at index.md

### DIFF
--- a/guides/tutorials/codelabs/kubernetes-v2-source-to-prod/index.md
+++ b/guides/tutorials/codelabs/kubernetes-v2-source-to-prod/index.md
@@ -368,7 +368,7 @@ kubectl proxy --context $STAGING_CONTEXT
 ```
 
 And then visit [the sample
-service](http://localhost:8001/api/v1/proxy/namespaces/default/services/spinnaker-demo:80/)
+service](http://localhost:8001/api/v1/namespaces/default/services/spinnaker-demo/proxy)
 in your browser. Let's make a change to this service, and configure Spinnaker
 to listen to Docker builds.
 


### PR DESCRIPTION
Correct the proxied service URL. 
I'm not sure if this is a k8s version issue, but at least when I want to access the proxied service this is the correct URL http://localhost:8001/api/v1/namespaces/default/services/spinnaker-demo/proxy/

Version info:
```
~ kubectl version
Client Version: version.Info{Major:"1", Minor:"10", GitVersion:"v1.10.4", GitCommit:"5ca598b4ba5abb89bb773071ce452e33fb66339d", GitTreeState:"clean", BuildDate:"2018-06-18T14:14:00Z", GoVersion:"go1.9.7", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"10+", GitVersion:"v1.10.5-gke.4", GitCommit:"6265b9797fc8680c8395abeab12c1e3bad14069a", GitTreeState:"clean", BuildDate:"2018-08-04T03:47:40Z", GoVersion:"go1.9.3b4", Compiler:"gc", Platform:"linux/amd64"}
```