### PR TITLE
Fix spinnaker clouddriver role json

### DIFF
--- a/setup/install/providers/aws/aws-ecs.md
+++ b/setup/install/providers/aws/aws-ecs.md
@@ -34,7 +34,7 @@ The role that Clouddriver assumes for your ECS account needs to have the trust r
                 "Service": [
                   "ecs.amazonaws.com",
                   "application-autoscaling.amazonaws.com"
-                ],
+                ]
       },
       "Action": "sts:AssumeRole"
     }


### PR DESCRIPTION
Deleted comma led to the "Bad string" error in AWS.
It was either a typo or an old syntax for IAM-roles
Deleting the comma fixes the problem.