### PR TITLE
fix(codelab): Add command to target cluster to gke-rbac codelab

### DIFF
--- a/setup/quickstart/halyard-gke-deploy-rbac/index.md
+++ b/setup/quickstart/halyard-gke-deploy-rbac/index.md
@@ -154,6 +154,10 @@ At the end of this guide you will have:
 5. Apply your changes to Spinnaker.
 
    ```bash
+   hal config deploy edit \
+       --account-name my-test-account \
+       --type distributed
+
    hal deploy apply
    ```
 


### PR DESCRIPTION
If a user follows the steps in this codelab in order, they'll deploy using a debian install to the machine running halyard rather than to their kubernetes cluster. Add the command that configures halyard to deploy to the kubernetes cluster.