### PR TITLE
fix(sql): fix syntax for code block

### DIFF
--- a/setup/productionize/persistence/orca-sql.md
+++ b/setup/productionize/persistence/orca-sql.md
@@ -29,6 +29,7 @@ Before deploying Orca, the schema and database uses must first be manually setup
 
 1. Set MySQL Server `tx_isolation` setting to `READ-COMMITTED`
 2. Setup the schema and database users
+  
   ```sql
   CREATE SCHEMA `orca` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 


### PR DESCRIPTION
the lack of an empty link between the code block was throwing a lot of
the rendering off