### PR TITLE
Fix typo: s/application/pipeline/

### DIFF
--- a/guides/spin/pipeline/index.md
+++ b/guides/spin/pipeline/index.md
@@ -59,7 +59,7 @@ You can also template the pipeline JSON using your favorite templating engine.
 ### List pipelines in an application with `list`
 
 ```bash
-spin application list --application my-app
+spin pipeline list --application my-app
 
 [
 ...


### PR DESCRIPTION
This fixes a typo in one of the cli examples. `spin application list` should be `spin pipeline list` in this case.