### PR TITLE
correct redis URI for database selection

### DIFF
--- a/setup/productionize/caching/externalize-redis.md
+++ b/setup/productionize/caching/externalize-redis.md
@@ -24,7 +24,7 @@ First, determine the URL of your Redis installation. Some examples include:
 * `redis://admin:passw0rd@some.redis.url:6379`: Same as above, but with
   a username/password pair.
 
-* `redis://admin:passw0rd@some.redis.url:6379?db=1`: Same as above, but using
+* `redis://admin:passw0rd@some.redis.url:6379/1`: Same as above, but using
   database 1. See [SELECT documentation](https://redis.io/commands/select).
 
 We will refer to this as `$REDIS_ENDPOINT`.


### PR DESCRIPTION
the original URI (redis://admin:passw0rd@some.redis.url:6379?db=1) does not work. it always selects db 0.
it has to be changed to redis://admin:passw0rd@some.redis.url:6379/1, then it works.
I verified this in redis 3.x and 4.x. not sure about redis 2.x. but I guess no one is using redis 2.x for production environment. so I simply suggest to update the URI.