### PR TITLE
typo in RBAC resource name

### DIFF
--- a/setup/install/providers/kubernetes-v2/index.md
+++ b/setup/install/providers/kubernetes-v2/index.md
@@ -101,7 +101,7 @@ metadata:
  name: spinnaker-role
 rules:
 - apiGroups: [""]
-  resources: ["namespaces", "configmaps", "events", "replicationcontrollers", "serviceaccounts", "pods/logs"]
+  resources: ["namespaces", "configmaps", "events", "replicationcontrollers", "serviceaccounts", "pods/log"]
   verbs: ["get", "list"]
 - apiGroups: [""]
   resources: ["pods", "services", "secrets"]


### PR DESCRIPTION
The correct is "pods/log"