### PR TITLE
Update quick-install.yml file for K8s to use 1.9.5

### DIFF
--- a/downloads/kubernetes/quick-install.yml
+++ b/downloads/kubernetes/quick-install.yml
@@ -151,7 +151,7 @@ data:
     currentDeployment: default
     deploymentConfigurations:
     - name: default
-      version: 1.9.0
+      version: 1.9.5
       providers:
         appengine:
           enabled: false


### PR DESCRIPTION
I will test this file with 1.10/1.11 in the near future.
In the meantime, we can safely go from 1.9.0 to 1.9.5.