### PR TITLE
fix(changelog): Move `deprecated` to tags list for 1.10.4

### DIFF
--- a/_changelogs/1.10.4-changelog.md
+++ b/_changelogs/1.10.4-changelog.md
@@ -2,7 +2,7 @@
 title: Version 1.10
 changelog_title: Version 1.10.4
 date: 2018-11-12 14:27:04 
-tags: changelogs 1.10
-version: 1.10.4 deprecated
+tags: changelogs 1.10 deprecated
+version: 1.10.4
 ---
 <script src="https://gist.github.com/spinnaker-release/73dba039067da5fbae6ec0b97b97e2f4.js"/>


### PR DESCRIPTION
@dorbin FYI