### PR TITLE
fix(changelogs): Order latest stable section by 'date' tag within cha…

### DIFF
--- a/community/releases/versions.md
+++ b/community/releases/versions.md
@@ -22,7 +22,7 @@ to see the commit hash and tag matching `version-<version>` of each
 subcomponent.
 
 ## Latest stable
-{% assign reversed = site.changelogs | sort_natural: 'changelog_title' | reverse  %}
+{% assign reversed = site.changelogs | sort: 'date' | reverse  %}
 {% for post in reversed %}
   {% unless post.tags contains 'deprecated' %}
 {% if post.version == blank %}


### PR DESCRIPTION
…ngelog's front matter.

This will just order them by the most recently released. If we make a patch in the latest version 1.N.M, it's possible that when we go patch 1.N-1, it will appear above 1.N.M, but we can manually adjust the date time if this really bothers someone.

Fixes https://github.com/spinnaker/spinnaker.github.io/issues/1061