### PR TITLE
Add install page for Cloud Foundry provider

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -51,6 +51,8 @@ setup:
                 url: /setup/install/providers/aws/aws-ecs/
           - title: Azure
             url: /setup/install/providers/azure/
+          - title: Cloud Foundry
+            url: /setup/install/providers/cf/
           - title: DC/OS
             url: /setup/install/providers/dcos/
           - title: Docker Registry

--- a/reference/providers/cf.md
+++ b/reference/providers/cf.md
@@ -5,7 +5,7 @@ sidebar:
   nav: reference
 ---
 
-{% include alpha version="1.10" %}
+{% include alpha version="1.10 and later" %}
 
 {% include toc %}
 

--- a/setup/install/providers/cf.md
+++ b/setup/install/providers/cf.md
@@ -1,0 +1,65 @@
+---
+layout: single
+title:  "Cloud Foundry"
+sidebar:
+  nav: setup
+redirect_from: /setup/providers/cf/
+---
+
+{% include alpha version="1.10 and later" %}
+
+{% include toc %}
+
+In [Cloud Foundry](https://www.cloudfoundry.org) (CF), an Account maps to a user account on a CF foundation. You can add multiple accounts for one or more CF foundations.
+
+## Prerequisites
+
+Your CF foundations' [API endpoints](https://docs.cloudfoundry.org/running/cf-api-endpoint.html) must be reachable from your installation of Spinnaker.
+
+## Adding an account
+
+While the Cloud Foundry provider is in alpha, the hal CLI does not have support for adding a CF account (this support will be added soon). Instead, you can use Halyard's [custom configuration](https://www.spinnaker.io/reference/halyard/custom/) to add a CF account to an existing installation of Spinnaker.
+
+On the machine running Halyard, Halyard creates a `.hal` directory. It contains a subdirectory for your Spinnaker deployment; by default, this subdirectory is called `default`. The deployment subdirectory itself contains a `profiles` subdirectory. Change to this subdirectory (an example path might be something like `~/.hal/default/profiles/`) and within it, create the two files shown below.
+
+Create a file called `settings-local.js`, with the following contents:
+
+```
+window.spinnakerSettings.providers.cloudfoundry = {
+  defaults: {account: 'my-cloudfoundry-account'}
+};
+```
+
+This file tells Spinnaker's Deck microservice to load functionality supporting CF.
+
+Create another file called `clouddriver-local.yml`, modifying the contents to include the relevant CF credentials:
+
+```
+cloudfoundry:
+  enabled: true
+  accounts:
+    - name: account-name
+      user: 'account-user'
+      password: 'account-password'
+      api: api.foundation.path
+    - name: optional-second-account
+      api: api.optional.second.foundation.path
+      user: 'second-account-user'
+      password: 'second-account-password'
+```
+
+This file gives Spinnaker account information with which to reach your CF instance.
+
+If you are setting up a new installation of Spinnaker, proceed to "Next steps" below.
+
+If you are working with an existing installation of Spinnaker, apply your changes:
+
+```
+$ hal deploy apply
+```
+
+Within a few minutes after applying your changes, you should be able to view the CF instance's existing applications from your installation of Spinnaker.
+
+## Next steps
+
+Optionally, you can [set up another cloud provider](https://www.spinnaker.io/setup/install/providers/), but otherwise you're ready to [choose an environment](https://www.spinnaker.io/setup/install/environment/) in which to install Spinnaker.

--- a/setup/install/providers/cf.md
+++ b/setup/install/providers/cf.md
@@ -10,13 +10,13 @@ redirect_from: /setup/providers/cf/
 
 {% include toc %}
 
-In [Cloud Foundry](https://www.cloudfoundry.org) (CF), an Account maps to a user account on a CF foundation. You can add multiple accounts for one or more CF foundations.
+In [Cloud Foundry](https://www.cloudfoundry.org) (CF), an Account maps to a user account on a CF foundation (a BOSH Director and all the VMs it deploys). You can add multiple accounts for one or more CF foundations.
 
 ## Prerequisites
 
 Your CF foundations' [API endpoints](https://docs.cloudfoundry.org/running/cf-api-endpoint.html) must be reachable from your installation of Spinnaker.
 
-## Adding an account
+## Add an account
 
 While the Cloud Foundry provider is in alpha, the hal CLI does not have support for adding a CF account (this support will be added soon). Instead, you can use Halyard's [custom configuration](https://www.spinnaker.io/reference/halyard/custom/) to add a CF account to an existing installation of Spinnaker.
 


### PR DESCRIPTION
Also update alpha notice on CF reference page... @dorbin @lwander could you let me know if a string as I have ("1.10 and later") is acceptable or is that broken and should I think of a different way of doing this?