### PR TITLE
fix(docs): Fix syntax error in Helm documentation

### DIFF
--- a/guides/user/kubernetes-v2/deploy-helm/index.md
+++ b/guides/user/kubernetes-v2/deploy-helm/index.md
@@ -50,10 +50,12 @@ When configuring the "Bake (Manifest)" stage, you can specify the following:
 > Note: Not all Helm charts contain namespace definitions in their manifests.
 > Make sure that your manifests contain the following code:
 
+{% raw %}
 ```yaml
 metadata:
   namespace: {{ .Release.Namespace }}
 ```
+{% endraw %}
 
 * __Zero or more override artifacts__ (optional)
 


### PR DESCRIPTION
We need to mark the code snippet as raw so it doesn't get
interpreted as a liquid template.

I'd noticed this error a few times when I built the docs site, but finally investigated; the `{{ .Release.Namespace }}` is just showing as blank on the live site right now.