### PR TITLE
docs(caching/externalize-redis): Fixed filepath for $SERVICE-local.yml

### DIFF
--- a/setup/productionize/caching/externalize-redis.md
+++ b/setup/productionize/caching/externalize-redis.md
@@ -53,7 +53,7 @@ installations yourself, Halyard does not create them for you_.
 
 Using [Halyard's custom
 configuration](/reference/halyard/custom#custom-profiles) we will
-create the following file `~/.hal/$DEPLOYMENT/profile-settings/$SERVICE-local.yml`:
+create the following file `~/.hal/$DEPLOYMENT/profiles/$SERVICE-local.yml`:
 
 ```yaml
 services.redis.baseUrl: $REDIS_ENDPOINT


### PR DESCRIPTION
Filepath was pointing to 
~/.hal/$DEPLOYMENT/profile-settings/$SERVICE-local.yml
while the correct path is
~/.hal/$DEPLOYMENT/profiles/$SERVICE-local.yml