### PR TITLE
Explicitly add $ACCOUNT variable

### DIFF
--- a/setup/install/providers/gce.md
+++ b/setup/install/providers/gce.md
@@ -101,7 +101,8 @@ SERVICE_ACCOUNT_DEST=# see Prerequisites section above
 Finally, add your new google account:
 
 ```bash
-hal config provider google account add my-gce-account --project $PROJECT \
+ACCOUNT=my-gce-account
+hal config provider google account add $ACCOUNT --project $PROJECT \
     --json-path $SERVICE_ACCOUNT_DEST
 ```
 


### PR DESCRIPTION
The variable `$ACCOUNT` is referenced on the next step but is not explicitly set in the prior step https://www.spinnaker.io/setup/install/environment/

This PR will help to reduce cognitive friction when determining the account name 