### PR TITLE
Make $CONTEXT explicit

### DIFF
--- a/setup/install/providers/kubernetes-v2/index.md
+++ b/setup/install/providers/kubernetes-v2/index.md
@@ -197,7 +197,7 @@ Then add the account:
 ```bash
 hal config provider kubernetes account add my-k8s-v2-account \
     --provider-version v2 \
-    --context $(kubectl config current-context)
+    --context $CONTEXT
 ```
 
 You'll also need to run

--- a/setup/install/providers/kubernetes-v2/index.md
+++ b/setup/install/providers/kubernetes-v2/index.md
@@ -195,6 +195,8 @@ hal config provider kubernetes enable
 Then add the account:
 
 ```bash
+CONTEXT=$(kubectl config current-context)
+
 hal config provider kubernetes account add my-k8s-v2-account \
     --provider-version v2 \
     --context $CONTEXT

--- a/setup/install/providers/kubernetes-v2/index.md
+++ b/setup/install/providers/kubernetes-v2/index.md
@@ -57,6 +57,8 @@ the following commands will create `spinnaker-service-account`, and add its
 token under a new user called `${CONTEXT}-token-user` in context `$CONTEXT`.
 
 ```bash
+CONTEXT=$(kubectl config current-context)
+
 # This service account uses the ClusterAdmin role -- this is not necessary, 
 # more restrictive roles can by applied.
 kubectl apply --context $CONTEXT \


### PR DESCRIPTION
Reduce cognitive overhead for new users trying to figure out what `$CONTEXT` is and where it comes from