### PR TITLE
fix(quick-install): remove trailing slash in API_HOST

### DIFF
--- a/downloads/kubernetes/quick-install.yml
+++ b/downloads/kubernetes/quick-install.yml
@@ -146,7 +146,7 @@ data:
   deck.yml: |
     host: 0.0.0.0
     env:
-      API_HOST: http://spin-gate.spinnaker:8084/
+      API_HOST: http://spin-gate.spinnaker:8084
   config: |
     currentDeployment: default
     deploymentConfigurations:


### PR DESCRIPTION
Thanks to @m-okeefe for pointing this out: https://github.com/spinnaker/spinnaker.github.io/issues/1154