### PR TITLE
docs(sigs): add sig schedules

### DIFF
--- a/community/governance/sigs.md
+++ b/community/governance/sigs.md
@@ -16,9 +16,9 @@ feature areas, and guide design in those areas.
 
 Below is a list of the current Spinnaker SIGs.
 
-| Name | Lead(s) | Agenda/Notes | Meeting Link | Contact |
-|-|-|-|-|-|
-| __Kubernetes__ | [lwander@](https://github.com/lwander), [ethanfrogers@](https://github.com/ethanfrogers) | [Link](https://docs.google.com/document/d/1db_yw1uru99Byvin4lQgm7aUZ9xMmvsARtEiiNUrmBo) | [Link (Meet)](https://meet.google.com/oto-qwpw-dgt) | [sig-kubernetes@spinnaker.io Mailing list](https://groups.google.com/a/spinnaker.io/forum/#!forum/sig-kubernetes), [#sig-kubernetes on Slack](https://spinnakerteam.slack.com) |
-| __Spinnaker As Code__ | [emjburns@](https://github.com/emjburns), [robfletcher@](https://github.com/robfletcher) | [Link](https://docs.google.com/document/d/1QP6WgHJiONH8mRaofRLN9lEwFfRsnm0ZBJVz8TOO9hw/edit) | [Link (Meet)](https://meet.google.com/shy-uixs-roo) | [#sig-spinnaker-as-code on slack](https://spinnakerteam.slack.com) |
+| Name | Lead(s) | Agenda/Notes | Meeting Link | Contact | Schedule |
+|-|-|-|-|-| - |
+| __Kubernetes__ | [lwander@](https://github.com/lwander), [ethanfrogers@](https://github.com/ethanfrogers) | [Link](https://docs.google.com/document/d/1db_yw1uru99Byvin4lQgm7aUZ9xMmvsARtEiiNUrmBo) | [Link (Meet)](https://meet.google.com/oto-qwpw-dgt) | [sig-kubernetes@spinnaker.io Mailing list](https://groups.google.com/a/spinnaker.io/forum/#!forum/sig-kubernetes), [#sig-kubernetes on Slack](https://spinnakerteam.slack.com) | Every other Tuesday, 1 PM EST / 10AM PST |
+| __Spinnaker As Code__ | [emjburns@](https://github.com/emjburns), [robfletcher@](https://github.com/robfletcher) | [Link](https://docs.google.com/document/d/1QP6WgHJiONH8mRaofRLN9lEwFfRsnm0ZBJVz8TOO9hw/edit) | [Link (Meet)](https://meet.google.com/shy-uixs-roo) | [#sig-spinnaker-as-code on slack](https://spinnakerteam.slack.com) | Every other Tuesday, 4 PM EST / 1 PM PST|
 
 If you think a new SIG should be launched in support of an under-served and important need in the project, please reach out to the [steering committee](/community/governance/#steering-committee) to start one!


### PR DESCRIPTION
add sig schedules so that it's more visible. it'd be nice to have a
"next meeting" section that updates automatically but this should
suffice for now.