### PR TITLE
DNMY docs(setup): remove netcat dependency to local git env setup

### DIFF
--- a/setup/install/environment.md
+++ b/setup/install/environment.md
@@ -127,7 +127,6 @@ Ensure that the following are installed on your system:
 
 * git: `sudo apt-get install git`
 * curl: `sudo apt-get install curl`
-* netcat: `sudo apt-get install netcat`
 * redis-server: `sudo apt-get install redis-server`
 * OpenJDK 8 - JDK (we're building from source, so a JRE is not sufficient)
     ```


### PR DESCRIPTION
This reverts commit c504abd5fc7d18be6f33db03595f2e17006ac7cd. No longer
needed once https://github.com/spinnaker/halyard/pull/1147 is merged.

Signed-off-by: Xavi León <xavi.leon@schibsted.com>