### PR TITLE
feat(sigs): add SIG meeting calendar, working slack links

### DIFF
--- a/community/governance/sigs.md
+++ b/community/governance/sigs.md
@@ -18,8 +18,22 @@ Below is a list of the current Spinnaker SIGs.
 
 | Name | Lead(s) | Agenda/Notes | Meeting Link | Contact | Schedule |
 |-|-|-|-|-| - |
-| __Kubernetes__ | [ethanfrogers@](https://github.com/ethanfrogers) | [Link](https://docs.google.com/document/d/1db_yw1uru99Byvin4lQgm7aUZ9xMmvsARtEiiNUrmBo) | [Link (Meet)](https://meet.google.com/oto-qwpw-dgt) | [sig-kubernetes@spinnaker.io Mailing list](https://groups.google.com/a/spinnaker.io/forum/#!forum/sig-kubernetes), [#sig-kubernetes on Slack](https://spinnakerteam.slack.com) | Every other Tuesday, 1 PM EST / 10AM PST |
-| __Spinnaker As Code__ | [emjburns@](https://github.com/emjburns), [robfletcher@](https://github.com/robfletcher) | [Link](https://docs.google.com/document/d/1QP6WgHJiONH8mRaofRLN9lEwFfRsnm0ZBJVz8TOO9hw/edit) | [Link (Meet)](https://meet.google.com/shy-uixs-roo) | [#sig-spinnaker-as-code on slack](https://spinnakerteam.slack.com) | Every other Tuesday, 4 PM EST / 1 PM PST|
-| __Security__ | [bpowell@](https://github.com/bpowell), [helenelau@](https://github.com/helenelau) | [Link](https://docs.google.com/document/d/1GhzhmG7ZytJBfW2lontOSBxVghgNZmxstF49SoocTDQ/edit) | [Link (Meet)](https://meet.google.com/rhf-kyvh-dre) | [#sig-security](https://spinnakerteam.slack.com) | Every other Thursday, 2 PM EST / 11 AM PST|
+| __Kubernetes__ | [ethanfrogers@](https://github.com/ethanfrogers) | [Link](https://docs.google.com/document/d/1db_yw1uru99Byvin4lQgm7aUZ9xMmvsARtEiiNUrmBo) | [Link (Meet)](https://meet.google.com/oto-qwpw-dgt) | [sig-kubernetes@spinnaker.io Mailing list](https://groups.google.com/a/spinnaker.io/forum/#!forum/sig-kubernetes), [#sig-kubernetes on Slack](https://spinnakerteam.slack.com/app_redirect?team=T091CRSGH&channel=C748G8U9J) | Every other Tuesday, 1 PM EST / 10AM PST |
+| __Spinnaker As Code__ | [emjburns@](https://github.com/emjburns), [robfletcher@](https://github.com/robfletcher) | [Link](https://docs.google.com/document/d/1QP6WgHJiONH8mRaofRLN9lEwFfRsnm0ZBJVz8TOO9hw/edit) | [Link (Meet)](https://meet.google.com/shy-uixs-roo) | [#sig-spinnaker-as-code on slack](https://spinnakerteam.slack.com/app_redirect?team=T091CRSGH&channel=CERACDPDZ) | Every other Tuesday, 4 PM EST / 1 PM PST|
+| __Security__ | [bpowell@](https://github.com/bpowell), [helenelau@](https://github.com/helenelau) | [Link](https://docs.google.com/document/d/1GhzhmG7ZytJBfW2lontOSBxVghgNZmxstF49SoocTDQ/edit) | [Link (Meet)](https://meet.google.com/rhf-kyvh-dre) | [#sig-security](https://spinnakerteam.slack.com/app_redirect?team=T091CRSGH&channel=CFN8F5UR2) | Every other Thursday, 2 PM EST / 11 AM PST|
 
 If you think a new SIG should be launched in support of an under-served and important need in the project, please reach out to the [steering committee](/community/governance/#steering-committee) to start one!
+
+# SIG Meeting Calendar
+
+There's a public calendar you can subscribe to which includes all SIG meetings. It will be updated
+when meetings are rescheduled or canceled.
+
+* If you use Google Calendar, [click here to subscribe](https://calendar.google.com/calendar/b/3?cid=c3Bpbm5ha2VyLmlvX3RyNjVyamY1bWZpajdwNnZ1Y3Bya2h1bGNjQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20).
+* If you don't use Google Calendar or have trouble with the first link, you can copy this iCal URL to subscribe using your calendar app of choice (instructions for [Google](https://support.google.com/calendar/answer/37100), [Apple Calendar](https://support.apple.com/guide/calendar/subscribe-to-calendars-icl1022/mac)):
+   ```
+   https://calendar.google.com/calendar/ical/spinnaker.io_tr65rjf5mfij7p6vucprkhulcc%40group.calendar.google.com/public/basic.ics
+   ```
+* If you don't want to subscribe directly, you can check the calendar below:
+
+<iframe src="https://calendar.google.com/calendar/b/3/embed?showPrint=0&amp;showCalendars=0&amp;mode=AGENDA&amp;height=500&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=spinnaker.io_tr65rjf5mfij7p6vucprkhulcc%40group.calendar.google.com&amp;color=%2342104A&amp;ctz=America%2FLos_Angeles" style="border-width:0" width="800" height="500" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
Right now it's a bit difficult for community members to keep track of when each SIG meeting takes place and/or notice when new SIG meetings start up. Got some positive feedback on the idea of creating a public calendar that folks could subscribe to which included all the various SIG meetings.

The calendar is owned by `sig@spinnaker.io`, and I've included a couple ways to subscribe to it along with an embedded view of upcoming events. We've got the as-code SIG partially on there now but I'll be reaching out to the SIG leads over the next few days to get their events onto the calendar as well.

While I was in here I also replaced the slack channel links (which just pointed to the overall workspace) and made them standard Slack deep links to the appropriate channel.

cc @bpowell @ethanfrogers @robfletcher @emjburns @helenelau