### PR TITLE
fix(appengine): Update the command for enabling App Engine Admin API

### DIFF
--- a/setup/install/providers/appengine.md
+++ b/setup/install/providers/appengine.md
@@ -35,7 +35,7 @@ gcloud app create --region <e.g., us-central>
 You will also need to enable the App Engine Admin API for your project:
 
 ```bash
-gcloud service-management enable appengine.googleapis.com
+gcloud services enable appengine.googleapis.com
 ```
 
 ## Downloading credentials


### PR DESCRIPTION
Using `service-management` throws this error `ERROR: (gcloud.service-management.enable) The "service-management enable" command has been replaced by "services enable".` We should use `services` command going forward. 

[Related Cloud docs](https://cloud.google.com/service-usage/docs/enable-disable)