### PR TITLE
docs(monitoring): adds lang identifier to code...

### DIFF
--- a/setup/monitoring/index.md
+++ b/setup/monitoring/index.md
@@ -77,7 +77,7 @@ the name of the meter is the name of the metric. The specification is flexible t
 allow for general rules about what to include or exclude. Only the clauses of
 interest need to be present.
 
-```
+```yaml
 meters:
   # If this section is empty, then all meters are assumed to match.
   #
@@ -97,13 +97,13 @@ meters:
     # If the name matches a regex here, it will not be included,
     # unless it also appears in byLiteralName.
     - <metric name regex>
-```
+```yaml
 
 ### Example Filter configurations
 
 Only include two metrics:
 
-```
+```yaml
 monitoring:
   filters:
     meters:
@@ -114,7 +114,7 @@ monitoring:
 
 Exclude add jvm and redis metrics
 
-```
+```yaml
 monitoring:
   filters:
     meters:
@@ -125,7 +125,7 @@ monitoring:
 
 Exclude all jvm metrics except for `jvm.memory.used`
 
-```
+```yaml
 monitoring:
   filters:
     meters:
@@ -138,7 +138,7 @@ monitoring:
 
 Include all jvm metrics except for `jvm.memory.used`
 
-```
+```yaml
 monitoring:
   filters:
     meters:


### PR DESCRIPTION
...blocks. For some reason, Google Search Console is claiming this one page is "too small to read on mobile." I don't find anything wrong with the page, and when I view it on mobile it looks like all the other pages. But I notice the code blocks didn't have a language identifier. I don't know why that would matter, and I doubt this is the only page that has such blocks, but it's something to try, to see if it can pass search console's validation.