### PR TITLE
Docs(nav): fixes obsolete link from left-nav...

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -223,7 +223,7 @@ guides:
           - title: Deploy GCS Pub/Sub Artifacts to Cloud Foundry
             url: /guides/tutorials/codelabs/pubsub-to-cf/
           - title: GCE Source To Prod
-            url: /guides/tutorials/codelabs/gce-source-to-prod/
+            url: https://codelabs.developers.google.com/codelabs/bake-and-deploy-pipeline
           - title: Kubernetes Source To Prod
             url: /guides/tutorials/codelabs/kubernetes-source-to-prod/
           - title: Kubernetes (Manifest Based) Source To Prod


### PR DESCRIPTION
to new GCE Source to Prod codelab.