### PR TITLE
Change case of argument

### DIFF
--- a/setup/install/providers/cf.md
+++ b/setup/install/providers/cf.md
@@ -34,8 +34,8 @@ hal config provider cloudfoundry account add my-cf-account \
   --user=[user-account] \
   --password=[user-password] \
   --environment=[dev,prod,...] \
-  --appsManagerURI=[http://apps.sys.endpoint.for.foundation] \
-  --metricsURI=[http://metrics.sys.endpoint.for.foundation]
+  --appsManagerUri=[http://apps.sys.endpoint.for.foundation] \
+  --metricsUri=[http://metrics.sys.endpoint.for.foundation]
 ```
 
 As part of the command execution Halyard will attempt to connect to the Cloud Foundry Foundation and return an error when this attempt fails.


### PR DESCRIPTION
When trying to use this sample command, I noticed the arguments are case sensitive in the version of halyard I am using (1.19.0) thus I had to modify the command shown to match the expected case.