### PR TITLE
Add links to GCS, GitHub, HTTP config instructions

### DIFF
--- a/setup/artifacts/index.md
+++ b/setup/artifacts/index.md
@@ -12,4 +12,7 @@ their ["type"](/reference/artifacts), they will need credentials to be
 downloaded or uploaded. These pages take you through configuring those
 credentials.
 
+* [Google Cloud Storage](/setup/artifacts/gcs/)
+* [GitHub](/setup/artifacts/github/)
+* [HTTP](/setup/artifacts/http/)
 * [Oracle Object](/setup/artifacts/oracle/)


### PR DESCRIPTION
Links to these sub-pages of the "Configure Artifact Support" section are currently missing