### PR TITLE
Add reference to artifact

### DIFF
--- a/guides/user/pipeline/triggers/webhooks/index.md
+++ b/guides/user/pipeline/triggers/webhooks/index.md
@@ -146,7 +146,8 @@ your payload under a list of `artifacts`:
   "artifacts": [
     {
       "type": "gcs/object",
-      "name": "gs://lw-artifacts/manifest.yml"
+      "name": "manifest.yml",
+      "reference": "gs://lw-artifacts/manifest.yml"
     }
   ]
 }


### PR DESCRIPTION
The artifact should have a reference defined to properly be fetched.