### PR TITLE
fix(docs): fix viewing {{ templateKey }} within this static site generator

### DIFF
--- a/guides/user/kubernetes-v2/annotations-ui/index.md
+++ b/guides/user/kubernetes-v2/annotations-ui/index.md
@@ -70,7 +70,7 @@ a single section title.
 
 Template values can be included in the content of the annotation and will be replaced when
 they are rendered by Deck.  A templated value has the following appearance in an annotation:
-`{{"{{ templateKey "}}}}` where `templateKey` will vary depending on the available set of keys
+`{{"{{ templateKey }}"}}` where `templateKey` will vary depending on the available set of keys
 for the resource that is annotated.  The complete set of available keys is documented below.
 
 #### Instances

--- a/guides/user/kubernetes-v2/annotations-ui/index.md
+++ b/guides/user/kubernetes-v2/annotations-ui/index.md
@@ -70,7 +70,7 @@ a single section title.
 
 Template values can be included in the content of the annotation and will be replaced when
 they are rendered by Deck.  A templated value has the following appearance in an annotation:
-`{{"{{ templateKey }}"}}` where `templateKey` will vary depending on the available set of keys
+`{{"{{ templateKey "}}}}` where `templateKey` will vary depending on the available set of keys
 for the resource that is annotated.  The complete set of available keys is documented below.
 
 #### Instances

--- a/guides/user/kubernetes-v2/run-job-manifest/index.md
+++ b/guides/user/kubernetes-v2/run-job-manifest/index.md
@@ -18,7 +18,7 @@ As with any job runner, logs are the primary form of feedback and it's important
 
 Most Kubernetes deployments will have some utility for forwarding logs from containers and into external systems for log analysis. If you're using one of these platforms, you can configure your `Job` with the annotation `jobs.spinnaker.io/logs` and a templated URL to your logging system. This value of this annotation will be used to render a link in the UI. 
 
-To make it easier to pinpoint the specific job, the annotation value can be templated with values from the deployed `Job` manifest. To use templates, use `{{ templateKey }}` where `templateKey` is the path to the value you wish to use. The deployed manifest will be passed into the template as JSON. This functionality mirrors that of the [Annotation Driven UI](/guides/user/kubernetes-v2/annotations-ui/).
+To make it easier to pinpoint the specific job, the annotation value can be templated with values from the deployed `Job` manifest. To use templates, use `{{ "{{ templateKey }}" }}` where `templateKey` is the path to the value you wish to use. The deployed manifest will be passed into the template as JSON. This functionality mirrors that of the [Annotation Driven UI](/guides/user/kubernetes-v2/annotations-ui/).
 
 For example, if your `Job` is deployed with name `myjob-12345`, the annotation...
 

--- a/guides/user/kubernetes-v2/run-job-manifest/index.md
+++ b/guides/user/kubernetes-v2/run-job-manifest/index.md
@@ -18,7 +18,7 @@ As with any job runner, logs are the primary form of feedback and it's important
 
 Most Kubernetes deployments will have some utility for forwarding logs from containers and into external systems for log analysis. If you're using one of these platforms, you can configure your `Job` with the annotation `jobs.spinnaker.io/logs` and a templated URL to your logging system. This value of this annotation will be used to render a link in the UI. 
 
-To make it easier to pinpoint the specific job, the annotation value can be templated with values from the deployed `Job` manifest. To use templates, use `{{ "{{ templateKey }}" }}` where `templateKey` is the path to the value you wish to use. The deployed manifest will be passed into the template as JSON. This functionality mirrors that of the [Annotation Driven UI](/guides/user/kubernetes-v2/annotations-ui/).
+To make it easier to pinpoint the specific job, the annotation value can be templated with values from the deployed `Job` manifest. To use templates, use `{{ "{{ templateKey "}} }}` where `templateKey` is the path to the value you wish to use. The deployed manifest will be passed into the template as JSON. This functionality mirrors that of the [Annotation Driven UI](/guides/user/kubernetes-v2/annotations-ui/).
 
 For example, if your `Job` is deployed with name `myjob-12345`, the annotation...
 


### PR DESCRIPTION
The current docs result in an empty `''` here: https://www.spinnaker.io/guides/user/kubernetes-v2/run-job-manifest/#link-to-external-system because the template isn't escaped.