### PR TITLE
docs(custom-job-stage): add missing label parameter to example snippet

### DIFF
--- a/guides/operator/custom-job-stages/index.md
+++ b/guides/operator/custom-job-stages/index.md
@@ -79,6 +79,7 @@ job:
         application: k8s2
         parameters:
           - name: PHRASE
+            label: Phrase to say
             description: Phrase to be echoed.
             mapping: manifest.spec.template.spec.containers[0].env[0].value
             defaultValue: "Hello world!"


### PR DESCRIPTION
added missing `label` property to example configuration snippet