### PR TITLE
fix(jobs): add forgotten _ character

### DIFF
--- a/guides/operator/custom-job-stages/index.md
+++ b/guides/operator/custom-job-stages/index.md
@@ -45,7 +45,7 @@ The following properties are supported for the `kubernetes` cloud provider.
 * `application` - Name of the application to associate the job with.
 * `manifest` - YAML definition for the [Kubernetes Job](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/) that will be run when the stage is executed.
 
-_Note: If you're using the slash (`/`) character in any manifest annotations, you'll need to use this [special syntax](https://github.com/spring-projects/spring-boot/issues/13404#issuecomment-395307439) to prevent the slash from being dropped when the application reads its configuration. For example, if your annotation key is `iam.amazonaws.com/role` you'll need to define it like so: `[iam.amazonaws.com/role]`.
+_Note: If you're using the slash (`/`) character in any manifest annotations, you'll need to use this [special syntax](https://github.com/spring-projects/spring-boot/issues/13404#issuecomment-395307439) to prevent the slash from being dropped when the application reads its configuration. For example, if your annotation key is `iam.amazonaws.com/role` you'll need to define it like so: `[iam.amazonaws.com/role]`._
 
 ### Custom Job Stages - Titus
 


### PR DESCRIPTION
note in jobs guide was missing a trailing `_` to make it italics.