### PR TITLE
Improve formatting for better syntax highlighting

### DIFF
--- a/guides/user/pipeline/pipeline-templates/instantiate.md
+++ b/guides/user/pipeline/pipeline-templates/instantiate.md
@@ -28,29 +28,29 @@ and get it using the following command:
    This outputs the JSON content of the template. You can save it in a file, or
    just examine it so that you know what you're implementing.
 
-1. Create a file, which will contain the JSON for the pipeline. 
+1. Create a file, which will contain the JSON for the pipeline.
 
    Use the following format:
 
    ```json
    {
-     “schema”: “v2”,
-     “application”: “myApp”, # Set this to the app you want to create the pipeline in.
-     “name”: “<pipeline name>”, # Pipeline name, remember this for the next part.
-     “template”: {
-       “artifactAccount”: “front50ArtifactCredentials”, # Static constant
-       “reference”: “spinnaker://newSpelTemplate”, # Reference to the pipeline template we published above. We saved it in Spinnaker, so we prefix the template id with ‘spinnaker://’.
-       “type”: “front50/pipelineTemplate”, # Static constant
+     "schema": "v2",
+     "application": "myApp", # Set this to the app you want to create the pipeline in.
+     "name": "<pipeline name>", # Pipeline name, remember this for the next part.
+     "template": {
+       "artifactAccount": "front50ArtifactCredentials", # Static constant
+       "reference": "spinnaker://newSpelTemplate", # Reference to the pipeline template we published above. We saved it in Spinnaker, so we prefix the template id with ‘spinnaker://’.
+       "type": "front50/pipelineTemplate", # Static constant
      },
-     “variables”: {
-       “waitTime”: 4 # Value for the template variable.
+     "variables": {
+       "waitTime": 4 # Value for the template variable.
      },
-     “inherit”: [],
-     “triggers”: [],
-     “parameters”: [],
-     “notifications”: [],
-     “description”: “”,
-     “stages”: []
+     "inherit": [],
+     "triggers": [],
+     "parameters": [],
+     "notifications": [],
+     "description": "",
+     "stages": []
    }
    ```
 


### PR DESCRIPTION
Hey there, I just noticed the slightly off JSON formatting in this code block. This should improve the syntax highlighting a bit, although it's of course still invalid JSON due to the comments. I was thinking perhaps adding a basic Markdown linter and formatting tool like [Prettier](https://prettier.io/blog/2017/11/07/1.8.0.html#markdown-support) for the future would also be beneficial. That's a separate discussion though. 🙂