### PR TITLE
Add pubsub enable instructions to GCB setup

### DIFF
--- a/setup/ci/gcb.md
+++ b/setup/ci/gcb.md
@@ -56,8 +56,10 @@ locking:
   enabled: true
 ```
 
-Use the following Halyard command to create a GCB account, enable the GCB integration, and re-deploy Spinnaker:
+Use the following Halyard commands to create a GCB account, enable the GCB integration, and re-deploy Spinnaker:
 ```
+    hal config pubsub google enable
+
     hal config ci gcb account add $ACCOUNT_NAME \
       --project $PROJECT_ID \
       --subscription-name $SUBSCRIPTION_NAME \


### PR DESCRIPTION
Closes #1413

As GCB relies on Google Pub/Sub users must have it enabled for GCB to work properly.