### PR TITLE
Add Google Cloud Build stage to the stage reference

### DIFF
--- a/reference/pipeline/stages/index.md
+++ b/reference/pipeline/stages/index.md
@@ -110,6 +110,13 @@ In Spinnaker, tags can only contain lowercase letters, numeric characters,
 underscores and dashes. Depending on your provider, you may need to specify what
 region to search for the image.
 
+### Google Cloud Build
+
+Run a Google Cloud Build build by specifing a build config as either an artifact or
+as inline YAML. Artifacts produced by the build can be injected into the pipeline
+and used by downstream stages. You must [configure Google Cloud Build](/setup/ci/gcb/)
+in order to use this stage.
+
 ### Jenkins
 Run the specified job in Jenkins. You must [set up Jenkins](/setup/ci/jenkins/)
 in order to use this stage. Once Jenkins is configured, your Jenkins master and


### PR DESCRIPTION
Closes #1387

Provide a brief overview, and link to the detailed instructions on configuring the stage.