### PR TITLE
Change suggested labels for traffic management

### DIFF
--- a/guides/user/kubernetes-v2/traffic-management/index.md
+++ b/guides/user/kubernetes-v2/traffic-management/index.md
@@ -169,7 +169,7 @@ You need the following:
     name: my-service
   spec:
     selector:
-      app: myapp
+      frontedBy: my-service # will be applied to backends by Spinnaker
     ports:
     - protocol: TCP
       port: 80
@@ -188,17 +188,17 @@ metadata:
     strategy.spinnaker.io/max-version-history: '2'
     traffic.spinnaker.io/load-balancers: '["service my-service"]'
   labels:
-    tier: frontend
-  name: frontend
+    app: myapp
+  name: myapp-frontend
 spec:
   replicas: 3
   selector:
     matchLabels:
-      tier: frontend
+      app: myapp
   template:
     metadata:
       labels:
-        tier: frontend
+        app: myapp
     spec:
       containers:
         - image: 'gcr.io/google_samples/gb-frontend:v3'


### PR DESCRIPTION
- Service has a "synthetic" label selector that indicates that it doesn't actually know what it will be pointing it
- ReplicaSet has labels that more closely reflect what a "normal" ReplicaSet would look like