### PR TITLE
fix(docs): Correct id propety to refId for injected stages

### DIFF
--- a/guides/user/pipeline/pipeline-templates/instantiate.md
+++ b/guides/user/pipeline/pipeline-templates/instantiate.md
@@ -120,14 +120,14 @@ stage.
 ```json
 "stages": [
     {
-        "id": "wait2",
+        "refId": "wait2",
         "type": "wait",
         "config": {
             "waitTime": 67
         }
     },
     {
-        "id": "wait0",
+        "refId": "wait0",
         "inject": {
             "after": ["wait2"]
         },


### PR DESCRIPTION
Correcting the docs to use the `refId` key.

https://github.com/spinnaker/spinnaker/issues/4704