### PR TITLE
fix(minio): Make note about running on localhost

### DIFF
--- a/setup/install/storage/minio.md
+++ b/setup/install/storage/minio.md
@@ -22,7 +22,7 @@ on an endpoint reachable by Spinnaker. Record the following values:
 
 * `ENDPOINT`: The fully-qualifed endpoint Minio is reachable on. If Minio is
   running on the same machine as Spinnaker, this might be
-  `http://localhost:9001`.
+  `http://127.0.0.1:9001` (note that using `localhost` instead of `127.0.0.1` generally won't work).
 
 * `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`: The access/secret keypair you've
   configured Minio with. These env vars need to be visible to the Minio process

--- a/setup/install/storage/minio.md
+++ b/setup/install/storage/minio.md
@@ -22,7 +22,7 @@ on an endpoint reachable by Spinnaker. Record the following values:
 
 * `ENDPOINT`: The fully-qualifed endpoint Minio is reachable on. If Minio is
   running on the same machine as Spinnaker, this might be
-  `http://127.0.0.1:9001` (note that using `localhost` instead of `127.0.0.1` generally won't work).
+  `http://127.0.0.1:9001` (note that using `localhost` instead of `127.0.0.1` doesn't work because the AWS SDK will then try to connect to http://<bucket-name>.localhost:9001).
 
 * `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`: The access/secret keypair you've
   configured Minio with. These env vars need to be visible to the Minio process


### PR DESCRIPTION
If using `http://localhost:9001`, the AWS SDK will try to connect to `http://<bucket-name>.localhost:9001`, which will not work.