### PR TITLE
Fix double quotes

### DIFF
--- a/guides/user/pipeline/pipeline-templates/create.md
+++ b/guides/user/pipeline/pipeline-templates/create.md
@@ -55,7 +55,7 @@ with a file that you can make available to `spin` CLI.
 Just by adding a few fields, you can turn this pipeline JSON into
 pipeline-template JSON.
 
-The following is the pipeline-template config format. Note the `"pipeline" :`
+The following is the pipeline-template config format. Note the `"pipeline":`
 section; it contains the pipeline JSON, the same as what's in ordinary pipeline
 JSON, but referencing any variables that are used. So as you start with a
 pipeline blob, you move that entire JSON fragment to the `pipeline` section.
@@ -63,7 +63,7 @@ pipeline blob, you move that entire JSON fragment to the `pipeline` section.
 1. Add a reference to the pipeline templates schema.
 
    ```json
-   "schema" : "v2",
+   "schema": "v2",
    ```
 
 1. Declare your variables.
@@ -72,20 +72,20 @@ pipeline blob, you move that entire JSON fragment to the `pipeline` section.
    reference in this template:
 
    ```json
-   "variables" : [
-   {
-     "type" : "<type>",
-     "defaultValue" : <defaultValue>,
-     "description" : "<some description>",
-     "name" : "<name of this variable>"
-   }
-   {
-     "type" : "<type>",
-     "defaultValue" : <defaultValue>,
-     "description" : "<some description>",
-     "name" : "<name of this variable>"
-   }
-     ]
+   "variables": [
+     {
+       "type": "<type>",
+       "defaultValue": <defaultValue>,
+       "description": "<some description>",
+       "name": "<name of this variable>"
+     }
+     {
+       "type": "<type>",
+       "defaultValue": <defaultValue>,
+       "description": "<some description>",
+       "name": "<name of this variable>"
+     }
+   ]
    ```
 
 1. For everything in the `pipeline` section that will be a variable, replace
@@ -97,11 +97,11 @@ declared in `variables`:
    For example in a non-templated pipeline, the amount of time to wait in a Wait
    stage would be represented by...
 
-   `"waitTime" : <time>`
+   `"waitTime": <time>`
 
    In our parameterized template, it would be...
 
-   `"waitTime" : "${ templateVariables.timeToWait }",`
+   `"waitTime": "${ templateVariables.timeToWait }",`
 
    ...where `timeToWait` is declared in the `variables` section of the template
    for this purpose.
@@ -111,40 +111,40 @@ list, and the pipeline definition:
 
 ```json
 {
-  "schema" : "v2", # Reference to the MPTv2 schema
-  "variables" : [
-  {
-    "type" : "int",
-    "defaultValue" : 42,
-    "description" : "The time a wait stage shall pauseth",
-    "name" : "timeToWait" # This is the name that's referenced in the SpEL expression later
-  }
+  "schema": "v2", # Reference to the MPTv2 schema
+  "variables": [
+    {
+      "type": "int",
+      "defaultValue": 42,
+      "description": "The time a wait stage shall pauseth",
+      "name": "timeToWait" # This is the name that's referenced in the SpEL expression later
+    }
   ],
-  "id" : "newSpelTemplate", # Main identifier to reference this template from instance
-  "protect" : false,
-  "metadata" : {
-    "name" : "Variable Wait",
-    "description" : "A demonstrative Wait Pipeline.",
-    "owner" : "example@example.com",
-    "scopes" : ["global"]
+  "id": "newSpelTemplate", # Main identifier to reference this template from instance
+  "protect": false,
+  "metadata": {
+    "name": "Variable Wait",
+    "description": "A demonstrative Wait Pipeline.",
+    "owner": "example@example.com",
+    "scopes": ["global"]
   },
   "pipeline": { # A "normal" pipeline definition.
-    "lastModifiedBy" : "anonymous",
-    "updateTs" : "0",
-    "parameterConfig" : [],
+    "lastModifiedBy": "anonymous",
+    "updateTs": "0",
+    "parameterConfig": [],
     "limitConcurrent": true,
     "keepWaitingPipelines": false,
-    "description" : "",
-    "triggers" : [],
-    "notifications" : [],
-    "stages" : [
-    {
-      "waitTime" : "${ templateVariables.timeToWait }", # Templated field.
-      "name": "My Wait Stage",
-      "type" : "wait",
-      "refId" : "wait1",
-      "requisiteStageRefIds": []
-    }
+    "description": "",
+    "triggers": [],
+    "notifications": [],
+    "stages": [
+      {
+        "waitTime": "${ templateVariables.timeToWait }", # Templated field.
+        "name": "My Wait Stage",
+        "type": "wait",
+        "refId": "wait1",
+        "requisiteStageRefIds": []
+      }
     ]
   }
 }

--- a/guides/user/pipeline/pipeline-templates/create.md
+++ b/guides/user/pipeline/pipeline-templates/create.md
@@ -78,7 +78,7 @@ pipeline blob, you move that entire JSON fragment to the `pipeline` section.
        "defaultValue": <defaultValue>,
        "description": "<some description>",
        "name": "<name of this variable>"
-     }
+     },
      {
        "type": "<type>",
        "defaultValue": <defaultValue>,

--- a/guides/user/pipeline/pipeline-templates/create.md
+++ b/guides/user/pipeline/pipeline-templates/create.md
@@ -78,7 +78,7 @@ pipeline blob, you move that entire JSON fragment to the `pipeline` section.
      "defaultValue" : <defaultValue>,
      "description" : "<some description>",
      "name" : "<name of this variable>"
-   } 
+   }
    {
      "type" : "<type>",
      "defaultValue" : <defaultValue>,
@@ -111,39 +111,39 @@ list, and the pipeline definition:
 
 ```json
 {
-  “schema” : “v2”, # Reference to the MPTv2 schema
-  “variables” : [
+  "schema" : "v2", # Reference to the MPTv2 schema
+  "variables" : [
   {
-    “type” : “int”,
-    “defaultValue” : 42,
-    “description” : “The time a wait stage shall pauseth”,
-    “name” : "timeToWait" # This is the name that's referenced in the SpEL expression later
+    "type" : "int",
+    "defaultValue" : 42,
+    "description" : "The time a wait stage shall pauseth",
+    "name" : "timeToWait" # This is the name that's referenced in the SpEL expression later
   }
   ],
-  “id” : “newSpelTemplate”, # Main identifier to reference this template from instance
-  “protect” : false,
-  “metadata” : {
-    “name” : “Variable Wait”,
-    “description” : “A demonstrative Wait Pipeline.”,
-    “owner” : “example@example.com”,
-    “scopes” : [“global”]
+  "id" : "newSpelTemplate", # Main identifier to reference this template from instance
+  "protect" : false,
+  "metadata" : {
+    "name" : "Variable Wait",
+    "description" : "A demonstrative Wait Pipeline.",
+    "owner" : "example@example.com",
+    "scopes" : ["global"]
   },
-  “pipeline”: { # A “normal” pipeline definition.
-    “lastModifiedBy” : “anonymous”,
-    “updateTs” : “0”,
-    “parameterConfig” : [],
-    “limitConcurrent”: true,
-    “keepWaitingPipelines”: false,
-    “description” : “”,
-    “triggers” : [],
-    “notifications” : [],
-    “stages” : [
+  "pipeline": { # A "normal" pipeline definition.
+    "lastModifiedBy" : "anonymous",
+    "updateTs" : "0",
+    "parameterConfig" : [],
+    "limitConcurrent": true,
+    "keepWaitingPipelines": false,
+    "description" : "",
+    "triggers" : [],
+    "notifications" : [],
+    "stages" : [
     {
-      “waitTime” : “${ templateVariables.timeToWait }”, # Templated field.
-      “name”: “My Wait Stage”,
-      “type” : “wait”,
-      “refId” : “wait1”,
-      “requisiteStageRefIds”: []
+      "waitTime" : "${ templateVariables.timeToWait }", # Templated field.
+      "name": "My Wait Stage",
+      "type" : "wait",
+      "refId" : "wait1",
+      "requisiteStageRefIds": []
     }
     ]
   }
@@ -156,7 +156,7 @@ list, and the pipeline definition:
 spin pipeline-templates save --file my_template.txt
 ```
 
-...where `my_template.txt` is the file in which you constructed the template JSON. 
+...where `my_template.txt` is the file in which you constructed the template JSON.
 
 `spin` checks that the file has a reference to the v2 schema and that it has a `pipeline` section.
 

--- a/reference/pipeline/templates/index.md
+++ b/reference/pipeline/templates/index.md
@@ -13,41 +13,41 @@ A pipeline template uses the following config JSON:
 
 ```
 {
-  "schema" : "v2",
-  "variables" : [
-  {
-    "type" : "<type>",
-    "defaultValue" : <value>,
-    "description" : "<description>",
-    "name" : "<varName>"
-  }
+  "schema": "v2",
+  "variables": [
+    {
+      "type": "<type>",
+      "defaultValue": <value>,
+      "description": "<description>",
+      "name": "<varName>"
+    }
   ],
-  "id" : "<templateName>", # The pipeline instance references the template using this
-  "protect" : <true | false>,
-  "metadata" : {
-    "name" : "displayName", # The display name shown in Deck
-    "description" : "<description>",
-    "owner" : "example@example.com",
-    "scopes" : ["global"] # not used
+  "id": "<templateName>", # The pipeline instance references the template using this
+  "protect": <true | false>,
+  "metadata": {
+    "name": "displayName", # The display name shown in Deck
+    "description": "<description>",
+    "owner": "example@example.com",
+    "scopes": ["global"] # not used
   },
   "pipeline": { # Contains the templatized pipeline itself
-    "lastModifiedBy" : "anonymous", # Not used
-    "updateTs" : "0", # not used
-    "parameterConfig" : [], # Same as in a regular pipeline
+    "lastModifiedBy": "anonymous", # Not used
+    "updateTs": "0", # not used
+    "parameterConfig": [], # Same as in a regular pipeline
     "limitConcurrent": true, # Same as in a regular pipeline
     "keepWaitingPipelines": false, # Same as in a regular pipeline
-    "description" : "", # Same as in a regular pipeline
-    "triggers" : [], # Same as in a regular pipeline
-    "notifications" : [], # Same as in a regular pipeline
-    "stages" : [  # Contains the templated stages
-    {
-      # This one is an example stage:
-      "waitTime" : "${ templateVariables.waitTime }", # Templated field.
-      "name": "My Wait Stage",
-      "type" : "wait",
-      "refId" : "wait1",
-      "requisiteStageRefIds": []
-    }
+    "description": "", # Same as in a regular pipeline
+    "triggers": [], # Same as in a regular pipeline
+    "notifications": [], # Same as in a regular pipeline
+    "stages": [  # Contains the templated stages
+      {
+        # This one is an example stage:
+        "waitTime": "${ templateVariables.waitTime }", # Templated field.
+        "name": "My Wait Stage",
+        "type": "wait",
+        "refId": "wait1",
+        "requisiteStageRefIds": []
+      }
     ]
   }
 }

--- a/reference/pipeline/templates/index.md
+++ b/reference/pipeline/templates/index.md
@@ -13,40 +13,40 @@ A pipeline template uses the following config JSON:
 
 ```
 {
-  “schema” : “v2”,
-  “variables” : [
+  "schema" : "v2",
+  "variables" : [
   {
-    “type” : “<type>”,
-    “defaultValue” : <value>,
-    “description” : “<description>”,
-    “name” : “<varName>”
+    "type" : "<type>",
+    "defaultValue" : <value>,
+    "description" : "<description>",
+    "name" : "<varName>"
   }
   ],
-  “id” : “<templateName>”, # The pipeline instance references the template using this
-  “protect” : <true | false>,
-  “metadata” : {
-    “name” : “displayName", # The display name shown in Deck
-    “description” : “<description>”,
-    “owner” : “example@example.com”,
-    “scopes” : [“global”] # not used
+  "id" : "<templateName>", # The pipeline instance references the template using this
+  "protect" : <true | false>,
+  "metadata" : {
+    "name" : "displayName", # The display name shown in Deck
+    "description" : "<description>",
+    "owner" : "example@example.com",
+    "scopes" : ["global"] # not used
   },
-  “pipeline”: { # Contains the templatized pipeline itself
-    “lastModifiedBy” : “anonymous”, # Not used
-    “updateTs” : “0”, # not used
-    “parameterConfig” : [], # Same as in a regular pipeline
-    “limitConcurrent”: true, # Same as in a regular pipeline 
-    “keepWaitingPipelines”: false, # Same as in a regular pipeline 
-    “description” : “”, # Same as in a regular pipeline 
-    “triggers” : [], # Same as in a regular pipeline 
-    “notifications” : [], # Same as in a regular pipeline 
-    “stages” : [  # Contains the templated stages
+  "pipeline": { # Contains the templatized pipeline itself
+    "lastModifiedBy" : "anonymous", # Not used
+    "updateTs" : "0", # not used
+    "parameterConfig" : [], # Same as in a regular pipeline
+    "limitConcurrent": true, # Same as in a regular pipeline
+    "keepWaitingPipelines": false, # Same as in a regular pipeline
+    "description" : "", # Same as in a regular pipeline
+    "triggers" : [], # Same as in a regular pipeline
+    "notifications" : [], # Same as in a regular pipeline
+    "stages" : [  # Contains the templated stages
     {
       # This one is an example stage:
-      “waitTime” : “${ templateVariables.waitTime }”, # Templated field.
-      “name”: “My Wait Stage”,
-      “type” : “wait”,
-      “refId” : “wait1”,
-      “requisiteStageRefIds”: []
+      "waitTime" : "${ templateVariables.waitTime }", # Templated field.
+      "name": "My Wait Stage",
+      "type" : "wait",
+      "refId" : "wait1",
+      "requisiteStageRefIds": []
     }
     ]
   }
@@ -60,24 +60,24 @@ config:
 
 ```
 {
-  “schema”: “v2”,
-  “application”: “<appName>”, # Set this to the app you want to create the pipeline in.
-  “name”: “New Pipeline Name”, # The name of your pipeline.
-  “template”: {
-    “source”: “spinnaker://<pipelineTemplateName>” # The `id` field from the pipeline template.
+  "schema": "v2",
+  "application": "<appName>", # Set this to the app you want to create the pipeline in.
+  "name": "New Pipeline Name", # The name of your pipeline.
+  "template": {
+    "source": "spinnaker://<pipelineTemplateName>" # The `id` field from the pipeline template.
                                                    # Assuming the template was saved in Spinnaker,
                                                    # you can prefix the id with ‘spinnaker://’.
                                                    # ‘http://’ and ‘file://’ prefixes are also supported.
   },
-  “variables”: {
-    “someVar”: <value> # Value for the template variable.
+  "variables": {
+    "someVar": <value> # Value for the template variable.
     "someOtherVar": <value>
   },
-  “inherit”: [],
-  “triggers”: [],
-  “parameters”: [],
-  “notifications”: [],
-  “description”: “”,
-  “stages”: []
+  "inherit": [],
+  "triggers": [],
+  "parameters": [],
+  "notifications": [],
+  "description": "",
+  "stages": []
 }
 ```


### PR DESCRIPTION
Fixed double-quote characters so that we can start trying pipeline template by copy & paste the sample json.

Also removed space character for consistency and added missing comma.