### PR TITLE
Fix how to refer template from a pipeline

### DIFF
--- a/reference/pipeline/templates/index.md
+++ b/reference/pipeline/templates/index.md
@@ -22,27 +22,27 @@ A pipeline template uses the following config JSON:
       "name": "<varName>"
     }
   ],
-  "id": "<templateName>", # The pipeline instance references the template using this
+  "id": "<templateName>",           # The pipeline instance references the template using this
   "protect": <true | false>,
   "metadata": {
-    "name": "displayName", # The display name shown in Deck
+    "name": "displayName",          # The display name shown in Deck
     "description": "<description>",
     "owner": "example@example.com",
-    "scopes": ["global"] # not used
+    "scopes": ["global"]            # Not used
   },
-  "pipeline": { # Contains the templatized pipeline itself
-    "lastModifiedBy": "anonymous", # Not used
-    "updateTs": "0", # not used
-    "parameterConfig": [], # Same as in a regular pipeline
-    "limitConcurrent": true, # Same as in a regular pipeline
-    "keepWaitingPipelines": false, # Same as in a regular pipeline
-    "description": "", # Same as in a regular pipeline
-    "triggers": [], # Same as in a regular pipeline
-    "notifications": [], # Same as in a regular pipeline
-    "stages": [  # Contains the templated stages
+  "pipeline": {                     # Contains the templatized pipeline itself
+    "lastModifiedBy": "anonymous",  # Not used
+    "updateTs": "0",                # Not used
+    "parameterConfig": [],          # Same as in a regular pipeline
+    "limitConcurrent": true,        # Same as in a regular pipeline
+    "keepWaitingPipelines": false,  # Same as in a regular pipeline
+    "description": "",              # Same as in a regular pipeline
+    "triggers": [],                 # Same as in a regular pipeline
+    "notifications": [],            # Same as in a regular pipeline
+    "stages": [                     # Contains the templated stages
       {
         # This one is an example stage:
-        "waitTime": "${ templateVariables.waitTime }", # Templated field.
+        "waitTime": "${ templateVariables.waitTime }",  # Templated field.
         "name": "My Wait Stage",
         "type": "wait",
         "refId": "wait1",
@@ -61,17 +61,17 @@ config:
 ```
 {
   "schema": "v2",
-  "application": "<appName>", # Set this to the app you want to create the pipeline in.
-  "name": "New Pipeline Name", # The name of your pipeline.
+  "application": "<appName>",     # Set this to the app you want to create the pipeline in.
+  "name": "New Pipeline Name",    # The name of your pipeline.
   "template": {
     "type": "front50/pipelineTemplate",
     "artifactAccount": "front50ArtifactCredentials",
     "reference": "spinnaker://<templateName>"   # The `id` field from the pipeline template.
-                                                        # Assuming the template was saved in Spinnaker,
-                                                        # you can prefix the id with ‘spinnaker://’.
+                                                # Assuming the template was saved in Spinnaker,
+                                                # you can prefix the id with ‘spinnaker://’.
   },
   "variables": {
-    "<varName>": <value>, # Value for the template variable.
+    "<varName>": <value>,         # Value for the template variable.
     "someOtherVar": <value>
   },
   "inherit": [],

--- a/reference/pipeline/templates/index.md
+++ b/reference/pipeline/templates/index.md
@@ -11,7 +11,7 @@ sidebar:
 
 A pipeline template uses the following config JSON:
 
-```
+```json
 {
   "schema": "v2",
   "variables": [
@@ -58,7 +58,7 @@ A pipeline template uses the following config JSON:
 A pipeline instance that implements a pipeline template uses the following
 config:
 
-```
+```json
 {
   "schema": "v2",
   "application": "<appName>",     # Set this to the app you want to create the pipeline in.

--- a/reference/pipeline/templates/index.md
+++ b/reference/pipeline/templates/index.md
@@ -66,9 +66,7 @@ config:
   "template": {
     "type": "front50/pipelineTemplate",
     "artifactAccount": "front50ArtifactCredentials",
-    "reference": "spinnaker://<templateName>"   # The `id` field from the pipeline template.
-                                                # Assuming the template was saved in Spinnaker,
-                                                # you can prefix the id with ‘spinnaker://’.
+    "reference": "spinnaker://<templateName>"
   },
   "variables": {
     "<varName>": <value>,         # Value for the template variable.
@@ -82,5 +80,3 @@ config:
   "stages": []
 }
 ```
-
-In `.template` section, `http://` and `file://` prefixes are also supported.

--- a/reference/pipeline/templates/index.md
+++ b/reference/pipeline/templates/index.md
@@ -64,13 +64,14 @@ config:
   "application": "<appName>", # Set this to the app you want to create the pipeline in.
   "name": "New Pipeline Name", # The name of your pipeline.
   "template": {
-    "source": "spinnaker://<pipelineTemplateName>" # The `id` field from the pipeline template.
-                                                   # Assuming the template was saved in Spinnaker,
-                                                   # you can prefix the id with ‘spinnaker://’.
-                                                   # ‘http://’ and ‘file://’ prefixes are also supported.
+    "type": "front50/pipelineTemplate",
+    "artifactAccount": "front50ArtifactCredentials",
+    "reference": "spinnaker://<templateName>"   # The `id` field from the pipeline template.
+                                                        # Assuming the template was saved in Spinnaker,
+                                                        # you can prefix the id with ‘spinnaker://’.
   },
   "variables": {
-    "someVar": <value> # Value for the template variable.
+    "<varName>": <value>, # Value for the template variable.
     "someOtherVar": <value>
   },
   "inherit": [],
@@ -81,3 +82,5 @@ config:
   "stages": []
 }
 ```
+
+In `.template` section, `http://` and `file://` prefixes are also supported.


### PR DESCRIPTION
Sharing the lesson I learned from https://github.com/spinnaker/spinnaker/issues/4735 ...

The `template` section in pipeline json should now be 

```json
  "template": {
    "type": "front50/pipelineTemplate",
    "artifactAccount": "front50ArtifactCredentials",
    "reference": "spinnaker://foo-template"
  },
```

instead of

```json
  "template": {
    "source": "spinnaker://foo-template"
  }
```

I have created a template and a dependent pipeline, and run it to confirm the updated example works (given that a user replaced placeholder values).

This PR also includes aesthetic changes, e.g. aligning comment lines in json, markdown `json` spec, consistent field values (`<templateName>` and `<varName>`)