### PR TITLE
'artifactsRewrite' artifact Reference: additions

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -542,6 +542,8 @@ reference:
             url: /reference/artifacts-with-artifactsrewrite/types/kubernetes-object/
           - title: Oracle Object
             url: /reference/artifacts-with-artifactsrewrite/types/oracle-object/
+          - title: Maven Artifact
+            url: /reference/artifacts-with-artifactsrewrite/types/maven-artifact/
   - title: Halyard
     collapsed: true
     children:

--- a/reference/artifacts-with-artifactsrewrite/index.md
+++ b/reference/artifacts-with-artifactsrewrite/index.md
@@ -7,6 +7,12 @@ sidebar:
 
 {% include toc %}
 
+> The pages in this section assume that you have enabled the `artifactsRewrite`
+> feature flag. In `~/.hal/$DEPLOYMENT/profiles/settings-local.js` (where
+> `$DEPLOYMENT` is typically `default`), add:
+>
+> `window.spinnakerSettings.feature.artifactsRewrite = true;`
+
 A Spinnaker artifact is a named JSON object that refers to an external resource.
 
 Spinnaker supports a wide range of providers. An artifact can reference any of many different external resources, such as&#8230;

--- a/reference/artifacts-with-artifactsrewrite/types/bitbucket-file/index.md
+++ b/reference/artifacts-with-artifactsrewrite/types/bitbucket-file/index.md
@@ -51,7 +51,9 @@ artifact.
 ### In a pipeline stage
 
 When configuring a "Deploy (Manifest)" or "Deploy" stage, you can use a
-Bitbucket file as a manifest or application artifact.
+Bitbucket file as a manifest or application artifact. You can either use a
+previously-defined artifact (for example, an artifact defined in a trigger) or
+define an artifact inline.
 
 ## Bitbucket file artifact in a pipeline definition
 

--- a/reference/artifacts-with-artifactsrewrite/types/docker-image/index.md
+++ b/reference/artifacts-with-artifactsrewrite/types/docker-image/index.md
@@ -54,7 +54,9 @@ expected artifact.
 ### In a pipeline stage
 
 When configuring certain stages, such as a  "Deploy (Manifest)" stage, you can
-use a Docker image as a required artifact.
+use a Docker image as a required artifact. You can either use a
+previously-defined artifact (for example, an artifact defined in a trigger) or
+define an artifact inline.
 
 {%
   include

--- a/reference/artifacts-with-artifactsrewrite/types/embedded-base64/index.md
+++ b/reference/artifacts-with-artifactsrewrite/types/embedded-base64/index.md
@@ -53,7 +53,9 @@ default artifact.
 ### In a pipeline stage
 
 When configuring certain stages, such as a "Deploy (Manifest)" stage, you can
-use embedded Base64 for a required artifact.
+use embedded Base64 for a required artifact. You can either use a
+previously-defined artifact (for example, an artifact defined in a trigger) or
+define an artifact inline.
 
 {%
   include

--- a/reference/artifacts-with-artifactsrewrite/types/gcs-object/index.md
+++ b/reference/artifacts-with-artifactsrewrite/types/gcs-object/index.md
@@ -51,7 +51,9 @@ System Type__ "Google"), you can use a GCS object as an expected artifact.
 ### In a pipeline stage
 
 When configuring a "Deploy (Manifest)" or "Deploy" stage, you can use a GCS
-object as a manifest or application artifact.
+object as a manifest or application artifact. You can either use a
+previously-defined artifact (for example, an artifact defined in a trigger) or
+define an artifact inline.
 
 {%
   include

--- a/reference/artifacts-with-artifactsrewrite/types/github-file/index.md
+++ b/reference/artifacts-with-artifactsrewrite/types/github-file/index.md
@@ -60,7 +60,9 @@ as an expected artifact.
 ### In a pipeline stage
 
 When configuring certain stages, such as a "Deploy (Manifest)" or "Deploy"
-stage, you can use a GitHub file as a manifest or application artifact.
+stage, you can use a GitHub file as a manifest or application artifact. You can
+either use a previously-defined artifact (for example, an artifact defined in a
+trigger) or define an artifact inline.
 
 {%
   include

--- a/reference/artifacts-with-artifactsrewrite/types/gitlab-file/index.md
+++ b/reference/artifacts-with-artifactsrewrite/types/gitlab-file/index.md
@@ -54,7 +54,9 @@ as an expected artifact.
 ### In a pipeline stage
 
 When configuring certain stages, such as a "Deploy (Manifest)" or "Deploy"
-stage, you can use a GitLab file as a manifest or application artifact.
+stage, you can use a GitLab file as a manifest or application artifact. You can
+either use a previously-defined artifact (for example, an artifact defined in a
+trigger) or define an artifact inline.
 
 ## GitLab file artifact in a pipeline definition
 

--- a/reference/artifacts-with-artifactsrewrite/types/http-file/index.md
+++ b/reference/artifacts-with-artifactsrewrite/types/http-file/index.md
@@ -53,7 +53,9 @@ artifact.
 ### In a pipeline stage
 
 When configuring a "Deploy (Manifest)" or "Deploy" stage, you can use an HTTP
-file as a manifest or application artifact.
+file as a manifest or application artifact. You can either use a
+previously-defined artifact (for example, an artifact defined in a trigger) or
+define an artifact inline.
 
 {%
   include

--- a/reference/artifacts-with-artifactsrewrite/types/maven-artifact/index.md
+++ b/reference/artifacts-with-artifactsrewrite/types/maven-artifact/index.md
@@ -34,7 +34,9 @@ When configuring certain triggers (such as an Artifactory trigger), you can use 
 
 ### In a pipeline stage
 
-When configuring a Deploy stage, you can use a Maven artifact as an application artifact.
+When configuring a Deploy stage, you can use a Maven artifact as an application
+artifact. You can either use a previously-defined artifact (for example, an
+artifact defined in a trigger) or define an artifact inline.
 
 {%
   include

--- a/reference/artifacts-with-artifactsrewrite/types/s3-object/index.md
+++ b/reference/artifacts-with-artifactsrewrite/types/s3-object/index.md
@@ -50,7 +50,9 @@ When configuring a trigger, you can use an S3 object as an expected artifact.
 ### In a pipeline stage
 
 When configuring a "Deploy (Manifest)" or "Deploy" stage, you can use an S3
-object as a manifest or application artifact.
+object as a manifest or application artifact. You can either use a
+previously-defined artifact (for example, an artifact defined in a trigger) or
+define an artifact inline.
 
 {%
   include


### PR DESCRIPTION
These are just things I missed in my last PR, #1475.

• Add 'Maven Artifact' to “New UI” navigation list of artifact types
• Add missing info on use of artifacts in pipeline stages (you can use either a previously-defined artifact, or define a new artifact inline--our screenshots all show inline, I think, but we need to mention the other possibility)

cc @dorbin 