### PR TITLE
doc(changelog)Deprecate 1.13.x

### DIFF
--- a/_changelogs/1.13.12-changelog.md
+++ b/_changelogs/1.13.12-changelog.md
@@ -2,7 +2,7 @@
 title: Version 1.13
 changelog_title: Version 1.13.12
 date: 2019-07-29 14:19:09 
-tags: changelogs 1.13
+tags: changelogs 1.13 deprecated
 version: 1.13.12
 ---
 <script src="https://gist.github.com/spinnaker-release/9ee98b0cbed65e334cd498bc31676295.js"/>

--- a/_changelogs/1.15.2-changelog.md
+++ b/_changelogs/1.15.2-changelog.md
@@ -2,7 +2,7 @@
 title: Version 1.15
 changelog_title: Version 1.15.2
 date: 2019-08-12 16:49:02 
-tags: changelogs 1.15
+tags: changelogs 1.15 deprecated
 version: 1.15.2
 ---
 <script src="https://gist.github.com/spinnaker-release/e72cc8015d544738d07d57a183cb5404.js"/>


### PR DESCRIPTION
also deprecates 1.15.2, latest is 1.15.3