### PR TITLE
fix(dev/kork): update command for publishing to maven local

### DIFF
--- a/guides/developer/kork-library.md
+++ b/guides/developer/kork-library.md
@@ -16,7 +16,7 @@ redirect_from: /docs/kork-library-dev
 ### Kork
 
 1. Make desired changes to `kork` module locally.
-2. Invoke `$ ./gradlew publishToMavenLocal`.
+2. Invoke `$ ./gradlew -PenablePublishing=true publishToMavenLocal`.
 3. Make note of the version printed:
 
 ```


### PR DESCRIPTION
The previous version of this command didn't work out of the box. I asked around and found that you have to manually override the property to enable publishing.