### PR TITLE
Links to Spinnaker certified operator installer from Red Hat 

### DIFF
--- a/setup/quickstart/index.md
+++ b/setup/quickstart/index.md
@@ -13,5 +13,5 @@ Here are a few quickstart solutions. These are not meant for production use. To 
 * [Kubernetes Helm Chart](https://github.com/kubernetes/charts/tree/master/stable/spinnaker)
 * [Kubernetes Operator](https://operatorhub.io/operator/spinnaker-operator)
 * [Red Hat certified Spinnaker Operator](https://access.redhat.com/containers/#/registry.connect.redhat.com/opsmx/spinnaker-operator)
-* [Spinnaker Operator based on ubi containers](https://github.com/OpsMx/opsmx-spinnaker-operator/tree/rhel)
+* [Spinnaker Operator based on UBI containers](https://github.com/OpsMx/opsmx-spinnaker-operator/tree/rhel)
 

--- a/setup/quickstart/index.md
+++ b/setup/quickstart/index.md
@@ -12,4 +12,6 @@ Here are a few quickstart solutions. These are not meant for production use. To 
 * [Microsoft Azure](https://aka.ms/azspinnaker)
 * [Kubernetes Helm Chart](https://github.com/kubernetes/charts/tree/master/stable/spinnaker)
 * [Kubernetes Operator](https://operatorhub.io/operator/spinnaker-operator)
+* [Red Hat certified Spinnaker Operator](https://access.redhat.com/containers/#/registry.connect.redhat.com/opsmx/spinnaker-operator)
+* [Spinnaker Operator based on ubi containers](https://github.com/OpsMx/opsmx-spinnaker-operator/tree/rhel)
 


### PR DESCRIPTION
Link to certified operator from Red Hat for installing Spinnaker on OpenShift platforms
Link to Spinnaker installer with Spinnaker services based on ubi images for Kubernetes deployments. These are not restricted to OpenShift flavor and can be installed on any Kubernetes flavors 