### PR TITLE
docs(changelogs): Deprecate v1.14.5

### DIFF
--- a/_changelogs/1.14.15-changelog.md
+++ b/_changelogs/1.14.15-changelog.md
@@ -2,7 +2,7 @@
 title: Version 1.14
 changelog_title: Version 1.14.15
 date: 2019-09-16 14:09:59 
-tags: changelogs 1.14
+tags: changelogs 1.14 deprecated
 version: 1.14.15
 ---
 <script src="https://gist.github.com/spinnaker-release/52b1de1551a8830a8945b3c49ef66fe3.js"/>


### PR DESCRIPTION
No longer supported with release of 1.17.0