### PR TITLE
chore(github): Add mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,12 @@
+pull_request_rules:
+  - name: Automatically merge on CI success and review
+    conditions:
+      - status-success=continuous-integration/travis-ci/pr
+      - "label=ready to merge"
+      - "approved-reviews-by=@oss-approvers"
+    actions:
+      merge:
+        method: squash
+        strict: smart
+      label:
+        add: ["auto merged"]


### PR DESCRIPTION
Automatically merge PRs when
a) `ready to merge` label is present, and
b) ci passed, and
c) the PR has at least 1 approval by someone who is a member of oss-approvers group