### PR TITLE
docs(cherrypicks): make sure to specify bug details on a cherrypick

### DIFF
--- a/community/contributing/releasing/index.md
+++ b/community/contributing/releasing/index.md
@@ -39,12 +39,12 @@ manager will be the person posting about the releases in [the
 channel](https://app.slack.com/client/T091CRSGH/CHD4ATAMV/). They will evaluate
 the patch, make sure it's appropriate and safe, and merge it if so.
 
-Please make sure your pull request references a bug with enough details to allow
-the release manager to evaluate your request. It should detail exactly what the
-impact of the bug is to users, how long it's been around, whether or not there
-are workarounds, etc. If there is no bug already open, you can either
-(preferably) file a new one, or else include these details in your cherrypick
-pull request.
+Please make sure your pull request references a GubHub issue with enough details
+to allow the release manager to evaluate your request. It should detail exactly
+what the impact of the bug is to users, how long it's been around, whether or
+not there are workarounds, etc. If there isn't an issue already open, you can
+either (preferably) file a new one, or else include these details in your
+cherrypick pull request.
 
 ## Cherry-pick using the GitHub bot
 

--- a/community/contributing/releasing/index.md
+++ b/community/contributing/releasing/index.md
@@ -39,7 +39,7 @@ manager will be the person posting about the releases in [the
 channel](https://app.slack.com/client/T091CRSGH/CHD4ATAMV/). They will evaluate
 the patch, make sure it's appropriate and safe, and merge it if so.
 
-Please make sure your pull request references a GubHub issue with enough details
+Please make sure your pull request references a GitHub issue with enough details
 to allow the release manager to evaluate your request. It should detail exactly
 what the impact of the bug is to users, how long it's been around, whether or
 not there are workarounds, etc. If there isn't an issue already open, you can

--- a/community/contributing/releasing/index.md
+++ b/community/contributing/releasing/index.md
@@ -39,6 +39,13 @@ manager will be the person posting about the releases in [the
 channel](https://app.slack.com/client/T091CRSGH/CHD4ATAMV/). They will evaluate
 the patch, make sure it's appropriate and safe, and merge it if so.
 
+Please make sure your pull request references a bug with enough details to allow
+the release manager to evaluate your request. It should detail exactly what the
+impact of the bug is to users, how long it's been around, whether or not there
+are workarounds, etc. If there is no bug already open, you can either
+(preferably) file a new one, or else include these details in your cherrypick
+pull request.
+
 ## Cherry-pick using the GitHub bot
 
 To cherry-pick into release `X.Y`, add the following comment to the _merged_ PR


### PR DESCRIPTION
Something like spinnaker/fiat#504 arguably warranted an immediate 1.17.1
release (rather than waiting until the normal Monday release), but since
the PR didn't actually say what it was fixing, it was pretty hard to
tell.