### PR TITLE
docs(setup/security/authorization): Fix Admin API Url

### DIFF
--- a/setup/security/authorization/google-groups/index.md
+++ b/setup/security/authorization/google-groups/index.md
@@ -16,7 +16,7 @@ to manage the roles users are granted.
 In order to access a user's group membership, we must use the Google Admin Directory API. We will
 setup a Google Cloud Platform (GCP) service account and grant it access to the Directory API.
 
-1. Enable the Admin SDK [here](https://console.cloud.google.com/apis/api/admin/overview){:target="\_blank"}.
+1. Enable the Admin SDK [here](https://console.cloud.google.com/apis/library/admin.googleapis.com){:target="\_blank"}.
 
 1. In your [Cloud Console](https://console.cloud.google.com){:target="\_blank"},
 create a service account that will access the G Suite Directory API.


### PR DESCRIPTION
The old url leads us to the error page which says `API solution not found with service name: admin.`

I do not know it **was** correct url, but I think it should be fixed.