### PR TITLE
add additional note regarding waiting before connecting!

### DIFF
--- a/setup/install/deploy.md
+++ b/setup/install/deploy.md
@@ -55,7 +55,7 @@ deploy apply`.
 
 
 __Note:__ Even if the `hal deploy apply` command returns successfully, the 
-installation may not be complete. This is especially the case with 
+installation may not be complete yet. This is especially the case with 
 kubernetes distributed installs. If you see errors such as `Connection refused`
 it may be that all of the containers are not yet available. You can either wait, 
 or check the status of all of the containers using the commands for your cloud

--- a/setup/install/deploy.md
+++ b/setup/install/deploy.md
@@ -37,6 +37,7 @@ hal deploy apply
 __Note:__ If you're deploying to your local machine, you might need `sudo hal
 deploy apply`.
 
+
 ## Connect to the Spinnaker UI
 
 1. Run the following command:
@@ -51,6 +52,15 @@ deploy apply`.
      service).
 
 1. Navigate to [localhost:9000](localhost:9000).
+
+
+__Note:__ Even if the `hal deploy apply` command returns successfully, the 
+installation may not be complete. This is especially the case with 
+kubernetes distributed installs. If you see errors such as `Connection refused`
+it may be that all of the containers are not yet available. You can either wait, 
+or check the status of all of the containers using the commands for your cloud
+provider (such as `kubectl get pods --namespace spinnaker`).
+
 
 ### Alternatives
 


### PR DESCRIPTION
It was not clear to me that even though halyard had completed successfully that all of the containers were not in a ready state. Until they are, using the hal deploy connect command and connecting to localhost:9000 will not work as connections will be refused. I added some wording in a note to suggest either watching the containers go ready or just waiting. In my case in a GCP deployment, 9 minutes needed to pass before all containers were ready and connections were successful. I'm open to other wording suggestions, but I do feel that a note here would be helpful to first time installers. 