### PR TITLE
chore(releases): Deprecate recently updated releases

### DIFF
--- a/_changelogs/1.15.6-changelog.md
+++ b/_changelogs/1.15.6-changelog.md
@@ -1,8 +1,8 @@
 ---
 title: Version 1.15
 changelog_title: Version 1.15.6
-date: 2019-10-23 16:58:57 
-tags: changelogs 1.15
+date: 2019-10-23 16:58:57
+tags: changelogs 1.15 deprecated
 version: 1.15.6
 ---
 <script src="https://gist.github.com/spinnaker-release/df4cad348c7f1a6ea6ced84c6fca70b7.js"/>

--- a/_changelogs/1.16.5-changelog.md
+++ b/_changelogs/1.16.5-changelog.md
@@ -1,8 +1,8 @@
 ---
 title: Version 1.16
 changelog_title: Version 1.16.5
-date: 2019-11-11 13:59:16 
-tags: changelogs 1.16
+date: 2019-11-11 13:59:16
+tags: changelogs 1.16 deprecated
 version: 1.16.5
 ---
 <script src="https://gist.github.com/spinnaker-release/12f98139a3cb3a126bfe3cfce44ebc69.js"/>

--- a/_changelogs/1.17.2-changelog.md
+++ b/_changelogs/1.17.2-changelog.md
@@ -1,8 +1,8 @@
 ---
 title: Version 1.17
 changelog_title: Version 1.17.2
-date: 2019-11-20 11:15:31 
-tags: changelogs 1.17
+date: 2019-11-20 11:15:31
+tags: changelogs 1.17 deprecated
 version: 1.17.2
 ---
 <script src="https://gist.github.com/spinnaker-release/67a07e48c68923e25dd9cc30fcddcf5b.js"/>


### PR DESCRIPTION
1.15 is currently running, but the other two are out. I'll update when 1.15.7 is out, and then we can merge this.