### PR TITLE
docs(update): Update Spin Sum banner

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,5 +1,10 @@
 ---
 layout: home
+conference_ad_row:
+  title: Spinnaker Summit 2019
+  excerpt: "Spinnaker Summit 2019 took place in San Diego, CA from November 15-17th. Hundreds of people from the Spinnaker community gathered and shared stories about their experiences with Spinnaker and Continuous Delivery. See the insights from Spinnaker contributors and users [here](https://www.youtube.com/playlist?list=PL4yLrwUObNkvGzXKSEU8miQTlvZyZvXWq)."
+  image_path: assets/images/summit-socialmedia-transparent.png
+  alt: "Spinnaker Summit Logo"
 spinnaker_row:
   title: Spinnaker is an open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
   excerpt: "Created at Netflix, it has been battle-tested in production by hundreds of teams over millions of deployments. It combines a powerful and flexible pipeline management system with integrations to the major cloud providers."

--- a/index.md
+++ b/index.md
@@ -1,10 +1,5 @@
 ---
 layout: home
-conference_ad_row:
-  title: Spinnaker Summit 2019
-  excerpt: "We're hosting a [conference](https://www.spinnakersummit.com) in San Diego, CA on November 15-17th. If you're interested in using Spinnaker, a current Spinnaker user, a Spinnaker operator, or in the DevOps space this conference will be interesting to you! \n \n We'd like to also extend a big \"Thank You!\" to the many many folks who submitted talks for this year. The review committee has started the process of reading through all of the proposals and will be publishing an official summit agenda soon."
-  image_path: assets/images/summit-socialmedia-transparent.png
-  alt: "Spinnaker Summit Logo"
 spinnaker_row:
   title: Spinnaker is an open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
   excerpt: "Created at Netflix, it has been battle-tested in production by hundreds of teams over millions of deployments. It combines a powerful and flexible pipeline management system with integrations to the major cloud providers."

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: home
 conference_ad_row:
   title: Spinnaker Summit 2019
-  excerpt: "Spinnaker Summit 2019 took place in San Diego, CA from November 15-17th. Hundreds of people from the Spinnaker community gathered and shared stories about their experiences with Spinnaker and Continuous Delivery. See the insights from Spinnaker contributors and users [here](https://www.youtube.com/playlist?list=PL4yLrwUObNkvGzXKSEU8miQTlvZyZvXWq)."
+  excerpt: "Spinnaker Summit 2019 took place in San Diego, CA from November 15-17th. Hundreds of people from the Spinnaker community gathered and shared stories about their experiences with Spinnaker and Continuous Delivery. See the insights from Spinnaker contributors and users in [full session recordings here](https://www.youtube.com/playlist?list=PL4yLrwUObNkvGzXKSEU8miQTlvZyZvXWq)."
   image_path: assets/images/summit-socialmedia-transparent.png
   alt: "Spinnaker Summit Logo"
 spinnaker_row:


### PR DESCRIPTION
This PR updates the SpinSum banner to link to the YouTube playlist. I suggest leaving this for a quarter and then removing it (or putting up the new SpinSum announcement depending on the timeline).

