### PR TITLE
chore(updates): update the community pages per SIG discussion

### DIFF
--- a/community/index.md
+++ b/community/index.md
@@ -178,7 +178,7 @@ Here are some ways to engage the Spinnaker community and find help&mdash;join us
 
 Start here! Many Spinnaker contributors and users are active on the Spinnaker Slack. It's a great place to get answers to questions or start a discussion about a feature or topic. Good places to begin on Slack include the following channels: 
 
-* A Special Interest Group (SIG) channel if there is a relevant one. SIGs are groups that focus on specific topics, such as , such as `#sig-security` or `#sig-documentation`. All SIG slack channels start with the prefix `sig`.
+* A Special Interest Group (SIG) channel if there is a relevant one. SIGs are groups that focus on specific topics, such as `#sig-security` or `#sig-documentation`. All SIG Slack channels start with the prefix `sig`.
 * A narrowly focused channel, such as #auth
 * [#general](https://spinnakerteam.slack.com/archives/C091CCWRJ) for general questions and discussion 
 * [#dev](https://spinnakerteam.slack.com/archives/C0DPVDMQE) for help contributing to Spinnaker

--- a/community/index.md
+++ b/community/index.md
@@ -178,7 +178,7 @@ Here are some ways to engage the Spinnaker community and find help&mdash;join us
 
 Start here! Many Spinnaker contributors and users are active on the Spinnaker Slack. It's a great place to get answers to questions or start a discussion about a feature or topic. Good places to begin on Slack include the following channels: 
 
-* A SIG channel if there is a relevant one, such as `#sig-security`. All SIG slack channels start with the prefix `sig`.
+* A Special Interest Group (SIG) channel if there is a relevant one. SIGs are groups that focus on specific topics, such as , such as `#sig-security` or `#sig-documentation`. All SIG slack channels start with the prefix `sig`.
 * A narrowly focused channel, such as #auth
 * [#general](https://spinnakerteam.slack.com/archives/C091CCWRJ) for general questions and discussion 
 * [#dev](https://spinnakerteam.slack.com/archives/C0DPVDMQE) for help contributing to Spinnaker

--- a/community/index.md
+++ b/community/index.md
@@ -176,9 +176,13 @@ Here are some ways to engage the Spinnaker community and find help&mdash;join us
 
 ### [Slack](http://join.spinnaker.io)
 
-Start here! Many Spinnaker contributors and users are active on the Spinnaker Slack. It's a great place to get answers to questions or start a discussion about a feature or topic. Good places to begin on Slack include the following channels: a SIG channel (if there is a relevant one), a narrowly focused channel (such as #auth), or even #general.
+Start here! Many Spinnaker contributors and users are active on the Spinnaker Slack. It's a great place to get answers to questions or start a discussion about a feature or topic. Good places to begin on Slack include the following channels: 
+
+* A SIG channel if there is a relevant one, such as `#sig-security`. All SIG slack channels start with the prefix `sig`.
+* A narrowly focused channel, such as #auth
+* [#general](https://spinnakerteam.slack.com/archives/C091CCWRJ) for general questions and discussion 
+* [#dev](https://spinnakerteam.slack.com/archives/C0DPVDMQE) for help contributing to Spinnaker
     
-All SIG slack channels start with the prefix `sig`. For example, the documentation SIG channel is `#sig-documentation`.
 
 ### [GitHub](https://github.com/spinnaker)
 
@@ -186,7 +190,7 @@ The Spinnaker org with repos for all the services and documentation. Come here t
     
 After engaging with the community to work through a problem, we encourage you to help us improve Spinnaker. File an issue if appropriate or even submit a fix. Reasons you might file an issue include the following: 
 
-* Your problem is due to a bug or limitation 
+* Your problem is due to a bug or limitation that is not documented 
 * The documentation is confusing or missing
 * The behavior of a feature or field is unclear
 

--- a/community/index.md
+++ b/community/index.md
@@ -168,24 +168,35 @@ chime_user:
   alt: "Chime Logo" 
 ---
 
+The Spinnaker OSS project was started at Netflix. Now, it thrives on the contributions of the broader DevOps community who have adopted it as their Continuous Delivery tool. 
+
 ## Engage the community and get support
 
-The Spinnaker OSS project was started at Netflix, and today thrives on the contributions and broad adoption of the public devops community. Here are some ways to engage the community and find help&mdash;join us!
+Here are some ways to engage the Spinnaker community and find help&mdash;join us!
 
-* [Spinnaker community forum](https://community.spinnaker.io)
+### [Slack](http://join.spinnaker.io)
 
-    Closely monitored by Spinnaker principal developers, this forum is a good place to initiate discussions that might go on for a while and that won't scroll off the screen before you notice them.
+Start here! Many Spinnaker contributors and users are active on the Spinnaker Slack. It's a great place to get answers to questions or start a discussion about a feature or topic. Good places to begin on Slack include the following channels: a SIG channel (if there is a relevant one), a narrowly focused channel (such as #auth), or even #general.
+    
+All SIG slack channels start with the prefix `sig`. For example, the documentation SIG channel is `#sig-documentation`.
 
-* [GitHub](https://github.com/spinnaker)
+### [GitHub](https://github.com/spinnaker)
 
-    The Spinnaker org, with repos for its many services. Come here to contribute to the Spinnaker services and documentation.
+The Spinnaker org with repos for all the services and documentation. Come here to contribute to Spinnaker!
+    
+After engaging with the community to work through a problem, we encourage you to help us improve Spinnaker. File an issue if appropriate or even submit a fix. Reasons you might file an issue include the following: 
 
-    If you find a problem, you can file an issue [here](https://github.com/spinnaker/spinnaker/issues). (However, if you just have a question, use one of the other resources listed here.)
+* Your problem is due to a bug or limitation 
+* The documentation is confusing or missing
+* The behavior of a feature or field is unclear
 
-* [Slack](http://join.spinnaker.io)
+You can file an issue [here](https://github.com/spinnaker/spinnaker/issues). 
 
-    A great place to get quick answers to questions that do not require extended, threaded discussion.
+## Project Governance
 
+Spinnaker is an OSS project owned and run by the community, through a structure of appointed roles. One important goal of this governance model is to make it easier for everyone to figure out how to get involved. If you want to get involved, we want to help you get there! As the project grows and its needs evolve, we will - as a community - continue to revisit and shape this structure.
+
+You can read more about how you can get involved through project SIGs, roles, and standing committees in the [Governance](https://github.com/spinnaker/community) section.
 
 ## Who's using Spinnaker?
 
@@ -299,10 +310,3 @@ The Spinnaker OSS project was started at Netflix, and today thrives on the contr
   </div>
 
 </div>
-
-## Project Governance
-
-Spinnaker is an OSS project owned and run by the community, through a structure of appointed roles. One important goal of this governance model is to make it easier for everyone to figure out how to get involved. If you want to get involved, we want to help you get there! As the project grows and its needs evolve, we will - as a community - continue to revisit and shape this structure.
-
-You can read more about how you can get involved through project SIGs, roles, and standing committees in the [Governance](https://github.com/spinnaker/community) section.
-

--- a/community/releases/support-policy.md
+++ b/community/releases/support-policy.md
@@ -11,15 +11,13 @@ redirect_from: /docs/support-policy
 ## Q&A
 
 If you have a question that isn't answered by our documents and FAQ pages,
-please reach out for help on [Slack](#slack).
+please reach out for help on [Slack](https://spinnakerteam.slack.com).
 
 The Spinnaker team hangs out on Slack in both the <code>#general</code> channel
 for general user-related discussions and the <code>#dev</code> channel for
 developer-related discussions. Additionally, Special Interest Groups (SIGs) have dedicated Slack channels, like #sig-security for the Security SIG.
 
-You can participate in the Spinnaker
-discussions [here](https://spinnakerteam.slack.com). Slack requires
-registration, but the Spinnaker team is open invitation to anyone to register
+Slack requires registration, but the Spinnaker team is open invitation to anyone to register
 [here](http://join.spinnaker.io). Feel free to come and ask any and all
 questions.
 

--- a/community/releases/support-policy.md
+++ b/community/releases/support-policy.md
@@ -8,6 +8,21 @@ redirect_from: /docs/support-policy
 
 {% include toc %}
 
+## Q&A
+
+If you have a question that isn't answered by our documents and FAQ pages,
+please reach out for help on [Slack](#slack).
+
+The Spinnaker team hangs out on Slack in both the <code>#general</code> channel
+for general user-related discussions and the <code>#dev</code> channel for
+developer-related discussions. Additionally, Special Interest Groups (SIGs) have dedicated Slack channels, like #sig-security for the Security SIG.
+
+You can participate in the Spinnaker
+discussions [here](https://spinnakerteam.slack.com). Slack requires
+registration, but the Spinnaker team is open invitation to anyone to register
+[here](http://join.spinnaker.io). Feel free to come and ask any and all
+questions.
+
 ## Bugs and feature requests
 
 If you have what looks like a bug, or you would like to make a feature request,
@@ -24,40 +39,3 @@ Some things to keep in mind:
   as possible! At the very least, provide the version of Spinnaker you are
   running, and what steps you took to reproduce the issue. The more information
   we have, the faster we can fix the problem.
-
-## Q&A
-
-If you have a question that isn't answered by our documents and FAQ pages,
-please reach out for help on [Discourse](#discourse), [Stack
-Overflow](#stack-overflow), or [Slack](#slack).
-
-### Discourse
-
-The [community discourse site](https://community.spinnaker.io) is the preferred
-spot for Spinnaker questions and discussion. Some things to keep in mind:
-
-* Please keep bug reports in the the [Spinnaker issue
-  tracker](https://github.com/spinnaker/spinnaker/issues).
-
-* If you think your question will involve a lot of troubleshooting and
-  back-and-forth questions, you might have more luck finding someone to answer
-  you in [Slack](#slack).
-
-### Stack Overflow
-
-Someone else from the community may have already asked a similar question or
-may be able to help you with your problem. The Spinnaker team will also monitor
-[posts tagged spinnaker](http://stackoverflow.com/questions/tagged/spinnaker).
-If there aren't any existing questions that help, please [ask a new
-one](http://stackoverflow.com/questions/ask?tags=spinnaker)!
-
-### Slack
-
-The Spinnaker team hangs out on Slack in both the <code>#general</code> channel
-for general user-related discussions and the <code>#dev</code> channel for
-developer-related discussions. You can participate in the Spinnaker
-discussions [here](https://spinnakerteam.slack.com). Slack requires
-registration, but the Spinnaker team is open invitation to anyone to register
-[here](http://join.spinnaker.io). Feel free to come and ask any and all
-questions.
-


### PR DESCRIPTION
This PR does the following:
- removes stack overflow
- removes the forum
- directs people to slack first and github second

PR for community repo: https://github.com/spinnaker/community/pull/76