### PR TITLE
chore(kubernetes): V1/V2 docs improvements

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -518,8 +518,6 @@ reference:
         url: /reference/providers/appengine/
       - title: Google Compute Engine
         url: /reference/providers/gce/
-      - title: Kubernetes (Legacy)
-        url: /reference/providers/kubernetes/
       - title: Kubernetes (Manifest Based)
         url: /reference/providers/kubernetes-v2/
       - title: Oracle Cloud

--- a/guides/tutorials/codelabs/kubernetes-v2-source-to-prod/index.md
+++ b/guides/tutorials/codelabs/kubernetes-v2-source-to-prod/index.md
@@ -3,6 +3,7 @@ layout: single
 title:  "Kubernetes Source To Prod (Manifest Based)"
 sidebar:
   nav: guides
+redirect_from: /guides/tutorials/codelabs/kubernetes-source-to-prod/
 ---
 
 {% include toc %}

--- a/setup/install/environment.md
+++ b/setup/install/environment.md
@@ -53,10 +53,7 @@ which you will install Spinnaker.
    This must be on a Kubernetes cluster. It does not have to be the same
    provider as the one you're using to deploy your applications.
 
-   * [Kubernetes](/setup/install/providers/kubernetes)
-
-   * [Kubernetes (Manifest Based)](/setup/install/providers/kubernetes-v2)<br />
-     :warning: This is still in alpha.
+   * [Kubernetes (Manifest Based)](/setup/install/providers/kubernetes-v2)
 
    We recommend at least 4 cores and 8GB of RAM available in the cluster where
    you will deploy Spinnaker.

--- a/setup/install/providers/index.md
+++ b/setup/install/providers/index.md
@@ -28,7 +28,6 @@ Add as many of the following providers as you need. When you're done, return to 
 * [Cloud Foundry](/setup/install/providers/cf/)
 * [DC/OS](/setup/install/providers/dcos/)
 * [Google Compute Engine](/setup/install/providers/gce/)
-* [Kubernetes (legacy)](/setup/install/providers/kubernetes/)
 * [Kubernetes V2 (manifest based)](/setup/install/providers/kubernetes-v2/)
 * [Oracle](/setup/install/providers/oracle/)
 

--- a/setup/quickstart/halyard-gke-deploy-rbac/index.md
+++ b/setup/quickstart/halyard-gke-deploy-rbac/index.md
@@ -147,7 +147,7 @@ At the end of this guide you will have:
 
    ```bash
    hal config provider kubernetes account add my-test-account \
-     --docker-registries my-gcr-account \
+     --provider-version v2 \
      --context $(kubectl config current-context)
    ```
 


### PR DESCRIPTION
- chore(kubernetes): remove inbound links to V1 installation
- chore(kubernetes): redirect from removed V1 codelab to V2 codelab
- chore(kubernetes): adjust hal command in rbac docs for v2