### PR TITLE
docs(java11): add note about java 11 migration

### DIFF
--- a/community/releases/versions.md
+++ b/community/releases/versions.md
@@ -22,6 +22,10 @@ to see the commit hash and tag matching `version-<version>` of each
 subcomponent.
 
 ## Latest stable
+
+**Note**: In upcoming versions, Spinnaker will be migrating to Java 11 from Java 8. This should not affect Spinnaker users. If you extend Spinnaker, this may affect you. For more information about the current status of the migration, see the [Java 11 RFC](https://github.com/spinnaker/governance/blob/master/rfc/java11.md).
+{: .notice--info}
+
 {% assign reversed = site.changelogs | sort: 'date' | reverse  %}
 {% for post in reversed %}
   {% unless post.tags contains 'deprecated' %}


### PR DESCRIPTION
We discussed adding this note during the SIG meeting before the holidays. 