### PR TITLE
fix(crd): fix crd extension docs

### DIFF
--- a/guides/developer/crd-extensions.md
+++ b/guides/developer/crd-extensions.md
@@ -46,7 +46,7 @@ public class MyCRDHandler extends KubernetesHandler {
 
   @Override
   public KubernetesKind kind() {
-    return "MyCRDKind";
+    return KubernetesKind.from("MyCRDKind");
   }
 
   @Override
@@ -70,10 +70,8 @@ public class MyCRDHandler extends KubernetesHandler {
   }
 
   @Override
-  public Class<? extends KubernetesV2CachingAgent> cachingAgentClass() {
-    // Caching agent class for your CRD.
-    // See, e.g., `KubernetesReplicaSetCachingAgent`.
-    return MyCRDCachingAgent.class;
+  public KubernetesV2CachingAgentFactory cachingAgentFactory() {
+    return KubernetesCoreCachingAgent::new;
   }
 }
 ```


### PR DESCRIPTION
the code in the `KubernetesHandler` section was outdated and didn't work
with an extension. I've updated the method signatures and content to
reflect the state of the class today.