### PR TITLE
docs(builds): Adds page with all repo build statuses

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -693,6 +693,8 @@ community:
         url: /community/contributing/
       - title: Code Of Conduct
         url: /community/contributing/code-of-conduct/
+      - title: Build Statuses
+        url: /community/contributing/build-statuses/
       - title: Submitting A Patch
         url: /community/contributing/submitting/
       - title: Nightly Builds

--- a/community/contributing/build-statuses/index.md
+++ b/community/contributing/build-statuses/index.md
@@ -1,0 +1,39 @@
+---
+title: Build Statuses
+sidebar:
+  nav: community
+---
+
+## Core Services
+
+* [![Clouddriver Build Status](https://api.travis-ci.org/spinnaker/clouddriver.svg?branch=master) Clouddriver](https://travis-ci.org/spinnaker/clouddriver){:target="\_blank"}
+* [![Deck Build Status](https://api.travis-ci.org/spinnaker/deck.svg?branch=master) Deck](https://travis-ci.org/spinnaker/deck){:target="\_blank"}
+* [![Deck-Kayenta Build Status](https://api.travis-ci.org/spinnaker/deck-kayenta.svg?branch=master) Deck-Kayenta](https://travis-ci.org/spinnaker/deck-kayenta){:target="\_blank"}
+* [![Echo Build Status](https://api.travis-ci.org/spinnaker/echo.svg?branch=master) Echo](https://travis-ci.org/spinnaker/echo){:target="\_blank"}
+* [![Fiat Build Status](https://api.travis-ci.org/spinnaker/fiat.svg?branch=master) Fiat](https://travis-ci.org/spinnaker/fiat){:target="\_blank"}
+* [![Front50 Build Status](https://api.travis-ci.org/spinnaker/front50.svg?branch=master) Front50](https://travis-ci.org/spinnaker/front50){:target="\_blank"}
+* [![Gate Build Status](https://api.travis-ci.org/spinnaker/gate.svg?branch=master) Gate](https://travis-ci.org/spinnaker/gate){:target="\_blank"}
+* [![Halyard Build Status](https://api.travis-ci.org/spinnaker/halyard.svg?branch=master) Halyard](https://travis-ci.org/spinnaker/halyard){:target="\_blank"}
+* [![Igor Build Status](https://github.com/spinnaker/igor/workflows/Igor%20CI/badge.svg)](https://github.com/spinnaker/igor/actions?query=workflow%3A%22Igor+CI%22+branch%3Amaster){:target="\_blank"} [![Igor Build Status](https://api.travis-ci.org/spinnaker/igor.svg?branch=master) Igor](https://travis-ci.org/spinnaker/igor){:target="\_blank"}
+* [![Kayenta Build Status](https://api.travis-ci.org/spinnaker/kayenta.svg?branch=master) Kayenta](https://travis-ci.org/spinnaker/kayenta){:target="\_blank"}
+* [![Kork Build Status](https://api.travis-ci.org/spinnaker/kork.svg?branch=master) Kork](https://travis-ci.org/spinnaker/kork){:target="\_blank"}
+* [![Orca Build Status](https://api.travis-ci.org/spinnaker/orca.svg?branch=master) Orca](https://travis-ci.org/spinnaker/orca){:target="\_blank"}
+* [![Rosco Build Status](https://api.travis-ci.org/spinnaker/rosco.svg?branch=master) Rosco](https://travis-ci.org/spinnaker/rosco){:target="\_blank"}
+
+## Optional and Supporting Services
+
+* [![Keel Build Status](https://api.travis-ci.org/spinnaker/keel.svg?branch=master) Keel](https://travis-ci.org/spinnaker/keel){:target="\_blank"}
+* [![Keiko Build Status](https://api.travis-ci.org/spinnaker/keiko.svg?branch=master) Keiko](https://travis-ci.org/spinnaker/keiko){:target="\_blank"}
+* [![Spin Build Status](https://api.travis-ci.org/spinnaker/spin.svg?branch=master) Spin](https://travis-ci.org/spinnaker/spin){:target="\_blank"}
+* [![Spinnaker Build Status](https://api.travis-ci.org/spinnaker/spinnaker.svg?branch=master) Spinnaker (main repo)](https://travis-ci.org/spinnaker/spinnaker){:target="\_blank"}
+* [![Spinnaker.io Docs site Build Status](https://api.travis-ci.org/spinnaker/spinnaker.github.io.svg?branch=master) Spinnaker.io Docs site](https://travis-ci.org/spinnaker/spinnaker.github.io){:target="\_blank"}
+* [![Spinnaker-gradle-project Build Status](https://api.travis-ci.org/spinnaker/spinnaker-gradle-project.svg?branch=master) Spinnaker-gradle-project](https://travis-ci.org/spinnaker/spinnaker-gradle-project){:target="\_blank"}
+* [![Spinnaker-monitoring Build Status](https://api.travis-ci.org/spinnaker/spinnaker-monitoring.svg?branch=master) Spinnaker-monitoring](https://travis-ci.org/spinnaker/spinnaker-monitoring){:target="\_blank"}
+* [![Swabbie Build Status](https://api.travis-ci.org/spinnaker/swabbie.svg?branch=master) Swabbie](https://travis-ci.org/spinnaker/swabbie){:target="\_blank"}
+
+
+## Nightly and Release Integration Tests
+
+Access the CI system here: [https://builds.spinnaker.io](https://builds.spinnaker.io){:target="\_blank"}
+
+> You must be a member of the `build-cops` GitHub Team to access this.


### PR DESCRIPTION
Igor is noticeably different because I think there is support to moving off of Metal Travis (:robot:) to GitHub Actions. Igor is my test repo for this.


![2VRKMeWAGsB](https://user-images.githubusercontent.com/13141550/73204061-53d36f80-410c-11ea-98cb-f238d3bd1690.png)


