### PR TITLE
docs(notices): remove old notices

### DIFF
--- a/guides/user/kubernetes-v2/rollout-strategies/index.md
+++ b/guides/user/kubernetes-v2/rollout-strategies/index.md
@@ -5,8 +5,6 @@ sidebar:
   nav: guides
 ---
 
-{% include alpha version="1.14" %}
-
 {% include toc %}
 
 This guide describes how to take advantage of the

--- a/reference/providers/cf.md
+++ b/reference/providers/cf.md
@@ -5,8 +5,6 @@ sidebar:
   nav: reference
 ---
 
-{% include alpha version="1.10 and later" %}
-
 {% include toc %}
 
 If you are not familiar with Cloud Foundry (CF) or any of the terms used below, please consult [Cloud Foundry's reference documentation](https://docs.cloudfoundry.org).

--- a/setup/security/authorization/pipeline-permissions/index.md
+++ b/setup/security/authorization/pipeline-permissions/index.md
@@ -5,8 +5,6 @@ sidebar:
   nav: setup
 ---
 
-{% include alpha version="1.9" %}
-
 {% include toc %}
 
 Pipeline permissions enable automatically triggered pipelines to modify


### PR DESCRIPTION
Removes the 1 year+ version notices that use `include alpha version`. Will submit subsequent ones based on wider searches. 

The K8s v2 notice is less than 1 year old now, but if we're deprecating v1, it makes sense to me to remove the alpha from v2.