### PR TITLE
chore(kubernetes): highlight upcoming v1 provider removal

### DIFF
--- a/reference/providers/kubernetes.md
+++ b/reference/providers/kubernetes.md
@@ -6,6 +6,9 @@ sidebar:
 redirect_from: /reference/providers/kubernetes-v1/
 ---
 
+> ⚠️ Spinnaker's legacy Kubernetes provider (V1) is [scheduled for removal](https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md) in Spinnaker 1.21.
+> We recommend using the [manifest-based provider (V2)](/setup/install/providers/kubernetes-v2) instead. 
+
 {% include toc %}
 
 If you are not familiar with Kubernetes or some of the Kubernetes terminology

--- a/reference/providers/kubernetes.md
+++ b/reference/providers/kubernetes.md
@@ -39,7 +39,7 @@ replaced.
 A Spinnaker **Server Group** maps to a Kubernetes [Replica
 Set](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/).
 The Spinnaker API resource is defined
-[here](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/servergroup/DeployKubernetesAtomicOperation.groovy).
+[here](https://github.com/spinnaker/clouddriver/blob/f89de41a805f9a043cfbbb3b9e9c78df1ad53360/clouddriver-kubernetes-v1/src/main/groovy/com/netflix/spinnaker/clouddriver/kubernetes/v1/deploy/ops/servergroup/DeployKubernetesAtomicOperation.groovy).
 
 When Spinnaker creates a Server Group named `${SERVER-GROUP}` it sets the
 following Pod labels:

--- a/reference/providers/kubernetes.md
+++ b/reference/providers/kubernetes.md
@@ -7,7 +7,7 @@ redirect_from: /reference/providers/kubernetes-v1/
 ---
 
 > ⚠️ Spinnaker's legacy Kubernetes provider (V1) is [scheduled for removal](https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md) in Spinnaker 1.21.
-> We recommend using the [manifest-based provider (V2)](/setup/install/providers/kubernetes-v2) instead. 
+> We recommend using the [manifest-based provider (V2)](/reference/providers/kubernetes-v2) instead. 
 
 {% include toc %}
 

--- a/setup/install/providers/kubernetes-v2/index.md
+++ b/setup/install/providers/kubernetes-v2/index.md
@@ -10,7 +10,7 @@ sidebar:
 
 The Spinnaker Kubernetes V2 provider fully supports manifest-based deployments and is the recommended provider for deploying to Kubernetes with Spinnaker.
 [Kubernetes provider V1](https://www.spinnaker.io/setup/install/providers/kubernetes/){:target="\_blank"}
-is in maintenance mode.
+is [scheduled for removal](https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md){:target="\_blank"} in Spinnaker 1.21.
 
 ## Accounts
 

--- a/setup/install/providers/kubernetes.md
+++ b/setup/install/providers/kubernetes.md
@@ -8,7 +8,7 @@ redirect_from:
  - /setup/install/providers/kubernetes-v1/
 ---
 
-> ⚠️ Spinnaker's legacy Kubernetes provider (V1) is in maintenance mode.
+> ⚠️ Spinnaker's legacy Kubernetes provider (V1) is [scheduled for removal](https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md) in Spinnaker 1.21.
 > We recommend using the [manifest-based provider (V2)](/setup/install/providers/kubernetes-v2) instead. 
 
 {% include toc %}


### PR DESCRIPTION
- chore(kubernetes): link to V1 provider removal RFC

  Replace "maintenance mode" with "removal" and link to the [spinnaker/governance RFC](https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md). I will adjust the language here to reflect the fact that the V1 provider _was removed_ when we release 1.21.

- chore(kubernetes): replace link to clouddriver at master with hash

  In the future, let's try to avoid linking from documentation to code. Since this particular link was useful enough that [a community member asked for it to be fixed](https://github.com/spinnaker/spinnaker/issues/5458), let's pin it to a specific commit hash rather than `master`.