### PR TITLE
docs(templates): Clarify template id reference

### DIFF
--- a/guides/user/pipeline/pipeline-templates/instantiate.md
+++ b/guides/user/pipeline/pipeline-templates/instantiate.md
@@ -64,7 +64,7 @@ and get it using the following command:
    ```json
    "template": {
      "artifactAccount": "front50ArtifactCredentials", # Static constant
-     "reference": "spinnaker://<templateName>",
+     "reference": "spinnaker://<templateId>",
      "type": "front50/pipelineTemplate" # Static constant
    }
    ```


### PR DESCRIPTION
Template name was misleading. This should reference the id, not the name in the template's metadata.