### PR TITLE
docs(halyard): use the correct JAVA_OPTS default values

### DIFF
--- a/reference/halyard/component-sizing.md
+++ b/reference/halyard/component-sizing.md
@@ -61,7 +61,7 @@ Limits and requests follow the Kubernetes conventions [documented here](https://
 All JVM-based services have the following JAVA_OPTS set:
 
 ```
-JAVA_OPTS=-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=2
+JAVA_OPTS=-XX:MaxRAMPercentage=50.0
 ```
 
 This sets the JVM's heap size to half the memory allocated per container. This can be overriden by specifying your own `JAVA_OPTS` 
@@ -71,7 +71,7 @@ As a starting point, the `-Xms` can be set to 80%-90% of the requests memory all
 
 ```
 env:
-   JAVA_OPTS: "-Xms410m -Xmx819m
+   JAVA_OPTS: "-Xms410m -Xmx819m"
 ```
 
 #### Recommendations


### PR DESCRIPTION
Fixes the least important part of spinnaker/spinnaker#5483