### PR TITLE
docs(managed-delivery): Update delivery config examples

### DIFF
--- a/guides/user/managed-delivery/delivery-configs/index.md
+++ b/guides/user/managed-delivery/delivery-configs/index.md
@@ -138,23 +138,19 @@ environments:
   notifications: # omitted for brevity
   constraints: []
   resources: # details omitted for brevity
-  - apiVersion: ec2.spinnaker.netflix.com/v1
-    kind: cluster
+  - kind: ec2/cluster@v1
     # details
-  - apiVersion: ec2.spinnaker.netflix.com/v1
-    kind: classic-load-balancer
-    # details    
+  - kind: ec2/classic-load-balancer@v1
+    # details
 - name: staging
   notifications: # omitted for brevity
   constraints: 
   - type: depends-on
     environment: testing
   resources: # details omitted for brevity
-  - apiVersion: ec2.spinnaker.netflix.com/v1
-    kind: cluster
+  - kind: ec2/cluster@v1
     # details
-  - apiVersion: ec2.spinnaker.netflix.com/v1
-    kind: classic-load-balancer
+  - kind: ec2/classic-load-balancer@v1
     # details 
 ```
 


### PR DESCRIPTION
Update the delivery config examples to reflect a recent change that merged the `apiVersion` and `kind` fields into a single `kind` fields.

See https://github.com/spinnaker/keel/pull/845