### PR TITLE
fix(entity tags): minor fixups to entity tags docs for ES6

### DIFF
--- a/guides/user/tagging/index.md
+++ b/guides/user/tagging/index.md
@@ -16,7 +16,7 @@ This is an *optional* feature of Spinnaker that requires
 - **Elasticsearch** (tested with 6.8.2)
 - **Front50** (backed by SQL, S3 or GCS)
 
-See [configuration](#Configuration) for specific configuration details.
+See [configuration](#configuration) for specific configuration details.
 
 # Overview
 


### PR DESCRIPTION
Now that entity tags have been migrated to ElasticSearch 6, doing a quick update to the docs to reflect that