### PR TITLE
chore(release): Deprecate 1.16.7

### DIFF
--- a/_changelogs/1.16.7-changelog.md
+++ b/_changelogs/1.16.7-changelog.md
@@ -2,7 +2,7 @@
 title: Version 1.16
 changelog_title: Version 1.16.7
 date: 2020-03-09 19:34:42 +0000
-tags: changelogs 1.16
+tags: changelogs 1.16 deprecated
 version: 1.16.7
 ---
 <script src="https://gist.github.com/spinnaker-release/170d178708b56e83b0289452cb83f347.js"/>


### PR DESCRIPTION
As we support 3 minor releases, the release of 1.19.0 means that the 1.16.x releases are now deprecated.