### PR TITLE
refactor(changelog): Update changelog links

### DIFF
--- a/_changelogs/1.17.0-changelog.md
+++ b/_changelogs/1.17.0-changelog.md
@@ -5,4 +5,4 @@ date: 2019-11-04 14:07:43
 tags: changelogs 1.17 deprecated
 version: 1.17.0
 ---
-<script src="https://gist.github.com/spinnaker-release/d20d6f7999cd22b860cacf7cb0a041ab.js"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"/>

--- a/_changelogs/1.17.1-changelog.md
+++ b/_changelogs/1.17.1-changelog.md
@@ -5,4 +5,4 @@ date: 2019-11-11 12:45:00
 tags: changelogs 1.17 deprecated
 version: 1.17.1
 ---
-<script src="https://gist.github.com/spinnaker-release/22f065966990c87dd128c8e342bc2a6e.js"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"/>

--- a/_changelogs/1.17.2-changelog.md
+++ b/_changelogs/1.17.2-changelog.md
@@ -5,4 +5,4 @@ date: 2019-11-20 11:15:31
 tags: changelogs 1.17 deprecated
 version: 1.17.2
 ---
-<script src="https://gist.github.com/spinnaker-release/67a07e48c68923e25dd9cc30fcddcf5b.js"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"/>

--- a/_changelogs/1.17.3-changelog.md
+++ b/_changelogs/1.17.3-changelog.md
@@ -5,4 +5,4 @@ date: 2019-12-03 08:51:01
 tags: changelogs 1.17 deprecated
 version: 1.17.3
 ---
-<script src="https://gist.github.com/spinnaker-release/1f3f18879006a583fa5122dfc89d6132.js"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.3.md"/>

--- a/_changelogs/1.17.4-changelog.md
+++ b/_changelogs/1.17.4-changelog.md
@@ -5,4 +5,4 @@ date: 2019-12-12 15:31:46 +0000
 tags: changelogs 1.17 deprecated
 version: 1.17.4
 ---
-<script src="https://gist.github.com/spinnaker-release/b885f807f9ef03c8783620d169bf43f9.js"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.4.md"/>

--- a/_changelogs/1.17.5-changelog.md
+++ b/_changelogs/1.17.5-changelog.md
@@ -5,4 +5,4 @@ date: 2019-12-16 21:21:31 +0000
 tags: changelogs 1.17 deprecated
 version: 1.17.5
 ---
-<script src="https://gist.github.com/spinnaker-release/11b548f1670c75683efaf98ed1a31761.js"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.5.md"/>

--- a/_changelogs/1.17.6-changelog.md
+++ b/_changelogs/1.17.6-changelog.md
@@ -5,4 +5,4 @@ date: 2020-01-14 14:19:54 +0000
 tags: changelogs 1.17 deprecated
 version: 1.17.6
 ---
-<script src="https://gist.github.com/spinnaker-release/3c23bfdc3493cca22664ba9b7771bc9d.js"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.6.md"/>

--- a/_changelogs/1.17.7-changelog.md
+++ b/_changelogs/1.17.7-changelog.md
@@ -5,4 +5,4 @@ date: 2020-03-09 19:37:53 +0000
 tags: changelogs 1.17
 version: 1.17.7
 ---
-<script src="https://gist.github.com/spinnaker-release/eea8c2434c8dcf77de8506ffec705246.js"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.7.md"/>

--- a/_changelogs/1.18.0-changelog.md
+++ b/_changelogs/1.18.0-changelog.md
@@ -5,4 +5,4 @@ date: 2020-01-22 13:18:57 +0000
 tags: changelogs 1.18 deprecated
 version: 1.18.0
 ---
-<script src="https://gist.github.com/spinnaker-release/6d9ebdbd548d72bec49c56442d2551d0.js"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"/>

--- a/_changelogs/1.18.1-changelog.md
+++ b/_changelogs/1.18.1-changelog.md
@@ -5,4 +5,4 @@ date: 2020-01-31 19:10:30 +0000
 tags: changelogs 1.18 deprecated
 version: 1.18.1
 ---
-<script src="https://gist.github.com/spinnaker-release/0df1df27e7c4c8e2784a0a0eea750a99.js"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"/>

--- a/_changelogs/1.18.2-changelog.md
+++ b/_changelogs/1.18.2-changelog.md
@@ -5,4 +5,4 @@ date: 2020-02-10 14:31:18 +0000
 tags: changelogs 1.18 deprecated
 version: 1.18.2
 ---
-<script src="https://gist.github.com/spinnaker-release/6a8f08f906ebe72bedcca8cd14322ae7.js"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.2.md"/>

--- a/_changelogs/1.18.3-changelog.md
+++ b/_changelogs/1.18.3-changelog.md
@@ -5,4 +5,4 @@ date: 2020-02-20 18:36:42 +0000
 tags: changelogs 1.18 deprecated
 version: 1.18.3
 ---
-<script src="https://gist.github.com/spinnaker-release/59e0c8280090b7a536f1d26e7f8f3d46.js"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.3.md"/>

--- a/_changelogs/1.18.4-changelog.md
+++ b/_changelogs/1.18.4-changelog.md
@@ -5,4 +5,4 @@ date: 2020-02-27 21:59:13 +0000
 tags: changelogs 1.18 deprecated
 version: 1.18.4
 ---
-<script src="https://gist.github.com/spinnaker-release/a7b148c63b4b8b0f6dc632ef3b9001cc.js"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.4.md"/>

--- a/_changelogs/1.18.5-changelog.md
+++ b/_changelogs/1.18.5-changelog.md
@@ -5,4 +5,4 @@ date: 2020-03-09 19:44:10 +0000
 tags: changelogs 1.18 deprecated
 version: 1.18.5
 ---
-<script src="https://gist.github.com/spinnaker-release/2cfb72a46883b82a657b4e4b8cba6f62.js"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.5.md"/>

--- a/_changelogs/1.18.6-changelog.md
+++ b/_changelogs/1.18.6-changelog.md
@@ -5,4 +5,4 @@ date: 2020-03-16 21:58:05 +0000
 tags: changelogs 1.18
 version: 1.18.6
 ---
-<script src="https://gist.github.com/spinnaker-release/9abbde0b0e44d545b6e7df09185c40ec.js"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.6.md"/>

--- a/_changelogs/1.19.0-changelog.md
+++ b/_changelogs/1.19.0-changelog.md
@@ -5,4 +5,4 @@ date: 2020-03-11 20:23:08 +0000
 tags: changelogs 1.19 deprecated
 version: 1.19.0
 ---
-<script src="https://gist.github.com/spinnaker-release/dbc44ac411d5076002b5db7c64b8c63e.js"/>
+<script src="https://gist.github.com/spinnaker-release/cc4410d674679c5765246a40f28e3cad.js?file=1.19.0.md"/>

--- a/_changelogs/1.19.1-changelog.md
+++ b/_changelogs/1.19.1-changelog.md
@@ -5,4 +5,4 @@ date: 2020-03-16 21:54:51 +0000
 tags: changelogs 1.19
 version: 1.19.1
 ---
-<script src="https://gist.github.com/spinnaker-release/47ea636047b9793cd72e8435cf072440.js"/>
+<script src="https://gist.github.com/spinnaker-release/cc4410d674679c5765246a40f28e3cad.js?file=1.19.1.md"/>


### PR DESCRIPTION
To simplify the build process, rather than create an entirely new gist for every release, we'll only create a gist for each minor Spinnaker version (1.18.x, 1.19.x, etc.). That gist will contain the release notes for each patch release within that minor version as separate files (ex: 1.18.2.md, 1.19.1.md).

I've created these gists for the 1.17, 1.18 and 1.19 branches; this points the docs site to these new gists. By passing the file URL parameter we will only embed the specific file related to the patch release in question, which means this change will result in no difference from a user's perspective; it just simplifies creating these gists.