### PR TITLE
chore(build): Simplify changelog gists

### DIFF
--- a/_changelogs/1.17.1-changelog.md
+++ b/_changelogs/1.17.1-changelog.md
@@ -6,3 +6,4 @@ tags: changelogs 1.17 deprecated
 version: 1.17.1
 ---
 <script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"/>

--- a/_changelogs/1.17.2-changelog.md
+++ b/_changelogs/1.17.2-changelog.md
@@ -6,3 +6,5 @@ tags: changelogs 1.17 deprecated
 version: 1.17.2
 ---
 <script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"/>

--- a/_changelogs/1.17.3-changelog.md
+++ b/_changelogs/1.17.3-changelog.md
@@ -6,3 +6,6 @@ tags: changelogs 1.17 deprecated
 version: 1.17.3
 ---
 <script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.3.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"/>

--- a/_changelogs/1.17.4-changelog.md
+++ b/_changelogs/1.17.4-changelog.md
@@ -6,3 +6,7 @@ tags: changelogs 1.17 deprecated
 version: 1.17.4
 ---
 <script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.4.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.3.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"/>

--- a/_changelogs/1.17.5-changelog.md
+++ b/_changelogs/1.17.5-changelog.md
@@ -6,3 +6,8 @@ tags: changelogs 1.17 deprecated
 version: 1.17.5
 ---
 <script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.5.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.4.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.3.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"/>

--- a/_changelogs/1.17.6-changelog.md
+++ b/_changelogs/1.17.6-changelog.md
@@ -6,3 +6,9 @@ tags: changelogs 1.17 deprecated
 version: 1.17.6
 ---
 <script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.6.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.5.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.4.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.3.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"/>

--- a/_changelogs/1.17.7-changelog.md
+++ b/_changelogs/1.17.7-changelog.md
@@ -6,3 +6,10 @@ tags: changelogs 1.17
 version: 1.17.7
 ---
 <script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.7.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.6.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.5.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.4.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.3.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"/>

--- a/_changelogs/1.18.1-changelog.md
+++ b/_changelogs/1.18.1-changelog.md
@@ -6,3 +6,4 @@ tags: changelogs 1.18 deprecated
 version: 1.18.1
 ---
 <script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"/>

--- a/_changelogs/1.18.2-changelog.md
+++ b/_changelogs/1.18.2-changelog.md
@@ -6,3 +6,5 @@ tags: changelogs 1.18 deprecated
 version: 1.18.2
 ---
 <script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.2.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"/>

--- a/_changelogs/1.18.3-changelog.md
+++ b/_changelogs/1.18.3-changelog.md
@@ -6,3 +6,6 @@ tags: changelogs 1.18 deprecated
 version: 1.18.3
 ---
 <script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.3.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.2.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"/>

--- a/_changelogs/1.18.4-changelog.md
+++ b/_changelogs/1.18.4-changelog.md
@@ -6,3 +6,7 @@ tags: changelogs 1.18 deprecated
 version: 1.18.4
 ---
 <script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.4.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.3.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.2.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"/>

--- a/_changelogs/1.18.5-changelog.md
+++ b/_changelogs/1.18.5-changelog.md
@@ -6,3 +6,8 @@ tags: changelogs 1.18 deprecated
 version: 1.18.5
 ---
 <script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.5.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.4.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.3.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.2.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"/>

--- a/_changelogs/1.18.6-changelog.md
+++ b/_changelogs/1.18.6-changelog.md
@@ -6,3 +6,9 @@ tags: changelogs 1.18
 version: 1.18.6
 ---
 <script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.6.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.5.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.4.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.3.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.2.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"/>

--- a/_changelogs/1.19.1-changelog.md
+++ b/_changelogs/1.19.1-changelog.md
@@ -6,3 +6,4 @@ tags: changelogs 1.19
 version: 1.19.1
 ---
 <script src="https://gist.github.com/spinnaker-release/cc4410d674679c5765246a40f28e3cad.js?file=1.19.1.md"/>
+<script src="https://gist.github.com/spinnaker-release/cc4410d674679c5765246a40f28e3cad.js?file=1.19.0.md"/>


### PR DESCRIPTION
The prior attempt to simplify changelog gists tried putting all the changelogs for a particular minor release as different files in the same gist.  This failed because for some releases we exceed the size that can be rendered for a gist (which causes failed rendering even if the particular file we're viewing is less than the max size).

The root cause was that we were copy-pasting the prior patch release's changlog into the new changelog and appending changes at the top.  This mean that, for example for 1.17.x, with 7 patch releases, we had the 1.17.0 release notes copied 7 times.

Rather than manually copy these release notes from gist to gist, let's just update the website to display the gists for the current patch release and all prior patch releases in order. This means that when making a new patch release, the gist just needs to contain the notes for that patch; the site will then incorporate the prior notes by reference. I have a corresponding update to the buildtool to update how we generate these changelog files, so they automatically pull all patch releases, but this PR is to backfill the currently-supported releases.  (I actually used the buildtool locally to generate this change.)

With this change, we greatly reduce the total size of the gist for each release, getting around the earlier problem.