### PR TITLE
fix(build): Fix script tags in changelog files

### DIFF
--- a/_changelogs/1.17.0-changelog.md
+++ b/_changelogs/1.17.0-changelog.md
@@ -5,4 +5,4 @@ date: 2019-11-04 14:07:43
 tags: changelogs 1.17 deprecated
 version: 1.17.0
 ---
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"></script>

--- a/_changelogs/1.17.1-changelog.md
+++ b/_changelogs/1.17.1-changelog.md
@@ -5,5 +5,5 @@ date: 2019-11-11 12:45:00
 tags: changelogs 1.17 deprecated
 version: 1.17.1
 ---
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"></script>

--- a/_changelogs/1.17.2-changelog.md
+++ b/_changelogs/1.17.2-changelog.md
@@ -5,6 +5,6 @@ date: 2019-11-20 11:15:31
 tags: changelogs 1.17 deprecated
 version: 1.17.2
 ---
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"></script>

--- a/_changelogs/1.17.3-changelog.md
+++ b/_changelogs/1.17.3-changelog.md
@@ -5,7 +5,7 @@ date: 2019-12-03 08:51:01
 tags: changelogs 1.17 deprecated
 version: 1.17.3
 ---
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.3.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.3.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"></script>

--- a/_changelogs/1.17.4-changelog.md
+++ b/_changelogs/1.17.4-changelog.md
@@ -5,8 +5,8 @@ date: 2019-12-12 15:31:46 +0000
 tags: changelogs 1.17 deprecated
 version: 1.17.4
 ---
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.4.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.3.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.4.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.3.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"></script>

--- a/_changelogs/1.17.5-changelog.md
+++ b/_changelogs/1.17.5-changelog.md
@@ -5,9 +5,9 @@ date: 2019-12-16 21:21:31 +0000
 tags: changelogs 1.17 deprecated
 version: 1.17.5
 ---
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.5.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.4.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.3.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.5.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.4.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.3.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"></script>

--- a/_changelogs/1.17.6-changelog.md
+++ b/_changelogs/1.17.6-changelog.md
@@ -5,10 +5,10 @@ date: 2020-01-14 14:19:54 +0000
 tags: changelogs 1.17 deprecated
 version: 1.17.6
 ---
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.6.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.5.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.4.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.3.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.6.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.5.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.4.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.3.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"></script>

--- a/_changelogs/1.17.7-changelog.md
+++ b/_changelogs/1.17.7-changelog.md
@@ -5,11 +5,11 @@ date: 2020-03-09 19:37:53 +0000
 tags: changelogs 1.17
 version: 1.17.7
 ---
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.7.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.6.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.5.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.4.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.3.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"/>
-<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"/>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.7.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.6.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.5.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.4.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.3.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.2.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.1.md"></script>
+<script src="https://gist.github.com/spinnaker-release/d020714e9190763f27e35701e14c6bc1.js?file=1.17.0.md"></script>

--- a/_changelogs/1.18.0-changelog.md
+++ b/_changelogs/1.18.0-changelog.md
@@ -5,4 +5,4 @@ date: 2020-01-22 13:18:57 +0000
 tags: changelogs 1.18 deprecated
 version: 1.18.0
 ---
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"></script>

--- a/_changelogs/1.18.1-changelog.md
+++ b/_changelogs/1.18.1-changelog.md
@@ -5,5 +5,5 @@ date: 2020-01-31 19:10:30 +0000
 tags: changelogs 1.18 deprecated
 version: 1.18.1
 ---
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"></script>

--- a/_changelogs/1.18.2-changelog.md
+++ b/_changelogs/1.18.2-changelog.md
@@ -5,6 +5,6 @@ date: 2020-02-10 14:31:18 +0000
 tags: changelogs 1.18 deprecated
 version: 1.18.2
 ---
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.2.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.2.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"></script>

--- a/_changelogs/1.18.3-changelog.md
+++ b/_changelogs/1.18.3-changelog.md
@@ -5,7 +5,7 @@ date: 2020-02-20 18:36:42 +0000
 tags: changelogs 1.18 deprecated
 version: 1.18.3
 ---
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.3.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.2.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.3.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.2.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"></script>

--- a/_changelogs/1.18.4-changelog.md
+++ b/_changelogs/1.18.4-changelog.md
@@ -5,8 +5,8 @@ date: 2020-02-27 21:59:13 +0000
 tags: changelogs 1.18 deprecated
 version: 1.18.4
 ---
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.4.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.3.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.2.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.4.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.3.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.2.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"></script>

--- a/_changelogs/1.18.5-changelog.md
+++ b/_changelogs/1.18.5-changelog.md
@@ -5,9 +5,9 @@ date: 2020-03-09 19:44:10 +0000
 tags: changelogs 1.18 deprecated
 version: 1.18.5
 ---
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.5.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.4.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.3.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.2.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.5.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.4.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.3.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.2.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"></script>

--- a/_changelogs/1.18.6-changelog.md
+++ b/_changelogs/1.18.6-changelog.md
@@ -5,10 +5,10 @@ date: 2020-03-16 21:58:05 +0000
 tags: changelogs 1.18
 version: 1.18.6
 ---
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.6.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.5.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.4.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.3.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.2.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"/>
-<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"/>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.6.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.5.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.4.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.3.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.2.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.1.md"></script>
+<script src="https://gist.github.com/spinnaker-release/306d7e241272980642e918f64ed91fe3.js?file=1.18.0.md"></script>

--- a/_changelogs/1.19.0-changelog.md
+++ b/_changelogs/1.19.0-changelog.md
@@ -5,4 +5,4 @@ date: 2020-03-11 20:23:08 +0000
 tags: changelogs 1.19 deprecated
 version: 1.19.0
 ---
-<script src="https://gist.github.com/spinnaker-release/cc4410d674679c5765246a40f28e3cad.js?file=1.19.0.md"/>
+<script src="https://gist.github.com/spinnaker-release/cc4410d674679c5765246a40f28e3cad.js?file=1.19.0.md"></script>

--- a/_changelogs/1.19.1-changelog.md
+++ b/_changelogs/1.19.1-changelog.md
@@ -5,5 +5,5 @@ date: 2020-03-16 21:54:51 +0000
 tags: changelogs 1.19
 version: 1.19.1
 ---
-<script src="https://gist.github.com/spinnaker-release/cc4410d674679c5765246a40f28e3cad.js?file=1.19.1.md"/>
-<script src="https://gist.github.com/spinnaker-release/cc4410d674679c5765246a40f28e3cad.js?file=1.19.0.md"/>
+<script src="https://gist.github.com/spinnaker-release/cc4410d674679c5765246a40f28e3cad.js?file=1.19.1.md"></script>
+<script src="https://gist.github.com/spinnaker-release/cc4410d674679c5765246a40f28e3cad.js?file=1.19.0.md"></script>


### PR DESCRIPTION
For some reason, only the first changelog is showing up after the last commit. Digging into this, I believe it's because we are incorrectly using a self-closing tag for the script element. This seems to have been working for a single script element but is breaking when there is more than one, causing only the first to show up.