### PR TITLE
docs(plugins): Update URL for plugin repos example

### DIFF
--- a/guides/user/plugin-users/index.md
+++ b/guides/user/plugin-users/index.md
@@ -120,7 +120,7 @@ Use `hal plugins repository add REPOSITORY [parameters]` to add the repository f
 
 ```
 hal plugins repository add spinnaker-plugin-examples \
-    --url=https://github.com/spinnaker-plugin-examples/examplePluginRepository/blob/master/repositories.json
+    --url=https://raw.githubusercontent.com/spinnaker-plugin-examples/examplePluginRepository/master/repositories.json
 ```
 
 See the command [reference](/reference/halyard/commands/#hal-plugins-repository) for a complete list of parameters.


### PR DESCRIPTION
the "add REPOSITORY" command does not work because the URL is incorrect, needs the raw content