### PR TITLE
chore(mergify): release-* branches require release manager approval

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,9 +1,36 @@
 pull_request_rules:
   - name: Automatically merge on CI success and review
     conditions:
+      - base=master
       - status-success=build
       - "label=ready to merge"
       - "approved-reviews-by=@oss-approvers"
+    actions:
+      merge:
+        method: squash
+        strict: smart
+      label:
+        add: ["auto merged"]
+  - name: Automatically merge release branch changes on CI success and release manager review
+    conditions:
+      - base~=^release-
+      - status-success=build
+      - "label=ready to merge"
+      - "approved-reviews-by=@release-managers"
+    actions:
+      merge:
+        method: squash
+        strict: smart
+      label:
+        add: ["auto merged"]
+  # This rule exists to handle release branches that are still building using Travis CI instead of
+  # using Github actions. It can be deleted once all active release branches are running Github actions.
+  - name: Automatically merge release branch changes on Travis CI success and release manager review
+    conditions:
+      - base~=^release-
+      - status-success=continuous-integration/travis-ci/pr
+      - "label=ready to merge"
+      - "approved-reviews-by=@release-managers"
     actions:
       merge:
         method: squash


### PR DESCRIPTION
The mergify config currently doesn't distinguish between merging to master and
merging to a release branch.  It currently never merges to release branches
because mergify doesn't have permission to merge to these branches (due to
branch protection rules).

I don't want to give mergify that permission without updating the config file
here, as then it would merge to release branches after any approval, whereas we
only want to merge to release branches if a PR is approved by a release manager.

This updates the mergify config to scope the existing rules to only apply to
the master branch, and adds a new rule to merge to release branches upon
approval by a release manager.

Because the 1.17 branch (and likely the 1.18 branch in some repos) is still
exclusively using Travis CI instead of github actions, also add a rule the
merges if Travis CI passes to account for these branches. This rule can be
deleted once all of the active branches in the repo are using Github actions.