### PR TITLE
docs(aws install): Put warning about stale AWS-EC2 install doc with link to temporary alternative

### DIFF
--- a/setup/install/providers/aws/aws-ec2.md
+++ b/setup/install/providers/aws/aws-ec2.md
@@ -8,7 +8,7 @@ sidebar:
 {% include toc %}
 
 > :warning: These instructions are out-of-date and a new version is being
-> worked on. In the meantime please use the following
+> worked on. In the meantime, please use the following
 > [AWS install tutorial](https://aws.amazon.com/blogs/opensource/continuous-delivery-spinnaker-amazon-eks/).
 
 In [AWS](https://aws.amazon.com/){:target="\_blank"}, an [__Account__](/concepts/providers/#accounts)

--- a/setup/install/providers/aws/aws-ec2.md
+++ b/setup/install/providers/aws/aws-ec2.md
@@ -9,7 +9,7 @@ sidebar:
 
 > :warning: These instructions are out-of-date and a new version is being
 > worked on. In the meantime please use the following
-> [AWS install tutorial](https://aws.amazon.com/blogs/opensource/continuous-delivery-spinnaker-amazon-eks/)
+> [AWS install tutorial](https://aws.amazon.com/blogs/opensource/continuous-delivery-spinnaker-amazon-eks/).
 
 In [AWS](https://aws.amazon.com/){:target="\_blank"}, an [__Account__](/concepts/providers/#accounts)
 maps to a credential able to authenticate against a given [AWS

--- a/setup/install/providers/aws/aws-ec2.md
+++ b/setup/install/providers/aws/aws-ec2.md
@@ -7,6 +7,10 @@ sidebar:
 
 {% include toc %}
 
+> :warning: These instructions are out-of-date and a new version is being
+> worked on. In the meantime please use the following
+> [AWS install tutorial](https://aws.amazon.com/blogs/opensource/continuous-delivery-spinnaker-amazon-eks/)
+
 In [AWS](https://aws.amazon.com/){:target="\_blank"}, an [__Account__](/concepts/providers/#accounts)
 maps to a credential able to authenticate against a given [AWS
 account](https://aws.amazon.com/account/){:target="\_blank"}.


### PR DESCRIPTION
Not sure if its prominent enough, but here is what it looks like:

<img width="669" alt="Screen Shot 2020-03-27 at 3 04 24 PM" src="https://user-images.githubusercontent.com/120980/77800456-774b6580-703c-11ea-99be-d5adf27a5459.png">
