### PR TITLE
doc(changelog): Revert extra Spinnaker Version 1.19.2

### DIFF
--- a/_changelogs/1.19.1-changelog.md
+++ b/_changelogs/1.19.1-changelog.md
@@ -2,7 +2,7 @@
 title: Version 1.19
 changelog_title: Version 1.19.1
 date: 2020-03-16 21:54:51 +0000
-tags: changelogs 1.19 deprecated deprecated
+tags: changelogs 1.19 deprecated
 version: 1.19.1
 ---
 <script src="https://gist.github.com/spinnaker-release/cc4410d674679c5765246a40f28e3cad.js?file=1.19.1.md"></script>

--- a/_changelogs/1.19.2-changelog.md
+++ b/_changelogs/1.19.2-changelog.md
@@ -1,7 +1,7 @@
 ---
 title: Version 1.19
 changelog_title: Version 1.19.2
-date: 2020-03-30 20:57:28 +0000
+date: 2020-03-20 21:17:01 +0000
 tags: changelogs 1.19 deprecated
 version: 1.19.2
 ---


### PR DESCRIPTION
I accidentally re-released 1.19.2; revert the change to the docs so the release time stays correct (and so that the extra deprecated on 1.19.1 goes away).

This reverts commit 51a7e74ec026d83adf35b12f5a69838657c36a65.