### PR TITLE
docs(plugins): Plugins Users Guide - add deploy pf4jStagePlugin example

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -393,8 +393,13 @@ guides:
         url: /guides/user/tagging/
       - title: Custom Instance Links
         url: /guides/user/instance-links/
-      - title: Plugin Users Guide
-        url: /guides/user/plugin-users/
+      - title: Plugins
+        collapsed: true
+        children:
+          - title: Users Guide
+            url: /guides/user/plugins/user-guide/
+          - title: pf4jStagePlugin Deployment Example
+            url: /guides/user/plugins/deploy-example/
       - title: Kubernetes (Manifest Based)
         collapsed: true
         children:

--- a/guides/developer/plugin-creators.md
+++ b/guides/developer/plugin-creators.md
@@ -11,7 +11,7 @@ sidebar:
   <strong>Note:</strong> Plugins are an early alpha feature that is under active development and will likely change.
 </div>
 
-This guide is for creating a new plugin to Spinnaker. For information about how to use an existing plugin, see [Plugin Users Guide](/guides/user/plugin-users/).
+This guide is for creating a new plugin to Spinnaker. For information about how to use an existing plugin, see [Plugin Users Guide](/guides/user/plugins/user-guide/).
 
 # Create the Backend For Stage Plugins
 

--- a/guides/user/plugins/deploy-example.md
+++ b/guides/user/plugins/deploy-example.md
@@ -31,14 +31,13 @@ These issues are fixed in Halyard 1.34.
 
 2. Create the `orca-local.yml` file in `.hal/default/profiles`. If you are using Halyard 1.33, see [Known Issues](#known-issues).
 
-3. Configure the plugin repository and redeploy Spinnaker:
+3. Configure the plugin repository:
 
 	```shell
   # Configure the plugin repository
 	hal plugins repository add spinnaker-plugin-examples \
 	  --url=https://raw.githubusercontent.com/spinnaker-plugin-examples/examplePluginRepository/master/repositories.json
 	# Apply your changes and deploy Spinnaker
-  hal deploy apply
 	```
 
 1. Add the pf4jStagePlugin:

--- a/guides/user/plugins/deploy-example.md
+++ b/guides/user/plugins/deploy-example.md
@@ -10,11 +10,12 @@ sidebar:
 {% include toc %}
 
 # Requirements
+
 * Spinnaker 1.19.4
 * Halyard 1.33
 * pf4jStagePlugin 1.0.16
 
-# Caveats with Halyard 1.33
+# Known Issues
 
 * Halyard does not update the plugin configuration when you run `hal plugins edit`. You must manually update the `.hal/config` entry.
 * Halyard does not tell Orca where to look for the plugin. Navigate to `.hal/default/profiles` and create an `orca-local.yml` file with this content:
@@ -26,19 +27,21 @@ These issues are fixed in Halyard 1.34.
 
 # Steps
 
-1. Download  [`RandomWaitStageIndex.js`](https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/releases/download/v1.0.16/RandomWaitStageIndex.js) and move the file to a publicly accessible location that supports CORs, such as an AWS S3 bucket.
+1. Download  [`RandomWaitStageIndex.js`](https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/releases/download/v1.0.16/RandomWaitStageIndex.js) and move the file to a publicly accessible location that supports Cross-Origin Resource Sharing (CORS), such as an AWS S3 bucket.
 
-1. Create the `orca-local.yml` file (see above).
+2. Create the `orca-local.yml` file in `.hal/default/profiles`. If you are using Halyard 1.33, see [Known Issues](#known-issues).
 
-1. Configure the plugin repository and redeploy Spinnaker.
+3. Configure the plugin repository and redeploy Spinnaker:
 
 	```shell
+  # Configure the plugin repository
 	hal plugins repository add spinnaker-plugin-examples \
 	  --url=https://raw.githubusercontent.com/spinnaker-plugin-examples/examplePluginRepository/master/repositories.json
-	hal deploy apply
+	# Apply your changes and deploy Spinnaker
+  hal deploy apply
 	```
 
-1. Add the pf4jStagePlugin.
+1. Add the pf4jStagePlugin:
 
 	```shell
 	hal plugins add Armory.RandomWaitPlugin \
@@ -48,7 +51,7 @@ These issues are fixed in Halyard 1.34.
 	  --ui-resource-location=https://aimeeu-plugins.s3.us-east-2.amazonaws.com/RandomWaitStageIndex.js
 	```
 
-1. Configure the plugin by editing its entry in the `hal config`.
+1. Configure the plugin by editing its entry in the Halconfig:
 
 	Base configuration:
 
@@ -72,7 +75,7 @@ These issues are fixed in Halyard 1.34.
           url: https://raw.githubusercontent.com/spinnaker-plugin-examples/examplePluginRepository/master/repositories.json
 	```
 
-	Add the `defaultMaxWaitTime` to the `config` list.
+	Add the `defaultMaxWaitTime` to the `config` list:
 
 	```yaml
     extensions:
@@ -84,7 +87,7 @@ These issues are fixed in Halyard 1.34.
 	```
 
 
-1. Redeploy Spinnaker.
+1. Redeploy Spinnaker:
 
 	```shell
 	hal deploy apply

--- a/guides/user/plugins/deploy-example.md
+++ b/guides/user/plugins/deploy-example.md
@@ -11,17 +11,23 @@ sidebar:
 
 # Requirements
 * Spinnaker 1.19.4
-* Halyard 1.34
-* pf4jStagePlugin 1.0.17
+* Halyard 1.33
+* pf4jStagePlugin 1.0.16
+
+# Caveats with Halyard 1.33
+
+* Halyard does not update the plugin configuration when you run `hal plugins edit`. You must manually update the `.hal\config` entry.
+* Halyard does not tell Orca where to look for the plugin. Navigate to `.hal/default/profiles` and create an `orca-local.yml` file with this content:
+
+	```yaml
+    spinnaker.extensibility.plugins-root-path: /opt/orca/plugins
+	```
 
 # Steps
-1. Download pf4jStagePlugin 1.0.17.  Unzip `pf4jStagePlugin-v1.0.17.zip` and then unzip `deck.zip`. Move the `RandomWaitStageIndex.js` file to a publicly accessible location that supports CORs, such as an AWS S3 bucket.
 
-	```shell
-	wget https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/releases/download/v1.0.17/pf4jStagePlugin-v1.0.17.zip
-	unzip pf4jStagePlugin-v1.0.17.zip
-	unzip deck.zip
-	```
+1. Download  [`RandomWaitStageIndex.js`](https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/releases/download/v1.0.16/RandomWaitStageIndex.js) and move the file to a publicly accessible location that supports CORs, such as an AWS S3 bucket.
+
+1. Create the `orca-local.yml` file (see above)
 
 1. Configure the plugin repository and redeploy Spinnaker
 
@@ -53,7 +59,7 @@ sidebar:
           id: Armory.RandomWaitPlugin
           enabled: true
           uiResourceLocation: https://aimeeu-plugins.s3.us-east-2.amazonaws.com/RandomWaitStageIndex.js
-          version: 1.0.17
+          version: 1.0.16
           extensions:
             armory.randomWaitStage:
               id: armory.randomWaitStage
@@ -76,11 +82,9 @@ sidebar:
           defaultMaxWaitTime: 60
 	```
 
+
 1. Redeploy Spinnaker
 
 	```shell
 	hal deploy apply
 	```
-
-1. a
-1. a

--- a/guides/user/plugins/deploy-example.md
+++ b/guides/user/plugins/deploy-example.md
@@ -1,0 +1,86 @@
+---
+layout: single
+title:  "pf4jStagePlugin Deployment Example"
+sidebar:
+  nav: guides
+---
+
+{% include alpha version="1.19.4" %}
+
+{% include toc %}
+
+# Requirements
+* Spinnaker 1.19.4
+* Halyard 1.34
+* pf4jStagePlugin 1.0.17
+
+# Steps
+1. Download pf4jStagePlugin 1.0.17.  Unzip `pf4jStagePlugin-v1.0.17.zip` and then unzip `deck.zip`. Move the `RandomWaitStageIndex.js` file to a publicly accessible location that supports CORs, such as an AWS S3 bucket.
+
+	```shell
+	wget https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/releases/download/v1.0.17/pf4jStagePlugin-v1.0.17.zip
+	unzip pf4jStagePlugin-v1.0.17.zip
+	unzip deck.zip
+	```
+
+1. Configure the plugin repository and redeploy Spinnaker
+
+	```shell
+	hal plugins repository add spinnaker-plugin-examples \
+	  --url=https://raw.githubusercontent.com/spinnaker-plugin-examples/examplePluginRepository/master/repositories.json
+	hal deploy apply
+	```
+
+1. Add the pf4jStagePlugin
+
+	```shell
+	hal plugins add Armory.RandomWaitPlugin \
+	  --enabled=true \
+	  --extensions=armory.randomWaitStage \
+	  --version=1.0.17 \
+	  --ui-resource-location=https://aimeeu-plugins.s3.us-east-2.amazonaws.com/RandomWaitStageIndex.js
+	```
+
+1. Configure the plugin by editing its entry in the `hal config`.
+
+	Base configuration:
+
+	```yaml
+   spinnaker:
+    extensibility:
+      plugins:
+        Armory.RandomWaitPlugin:
+          id: Armory.RandomWaitPlugin
+          enabled: true
+          uiResourceLocation: https://aimeeu-plugins.s3.us-east-2.amazonaws.com/RandomWaitStageIndex.js
+          version: 1.0.17
+          extensions:
+            armory.randomWaitStage:
+              id: armory.randomWaitStage
+              enabled: true
+              config: {}
+      repositories:
+        spinnaker-plugin-examples:
+          id: spinnaker-plugin-examples
+          url: https://raw.githubusercontent.com/spinnaker-plugin-examples/examplePluginRepository/master/repositories.json
+	```
+
+	Add the `defaultMaxWaitTime` to the `config` list.
+
+	```yaml
+    extensions:
+      armory.randomWaitStage:
+        id: armory.randomWaitStage
+        enabled: true
+        config:
+          defaultMaxWaitTime: 60
+	```
+
+1. Redeploy Spinnaker
+
+	```shell
+	hal deploy apply
+	```
+
+1. a
+1. a

--- a/guides/user/plugins/deploy-example.md
+++ b/guides/user/plugins/deploy-example.md
@@ -22,6 +22,7 @@ sidebar:
 	```yaml
     spinnaker.extensibility.plugins-root-path: /opt/orca/plugins
 	```
+These issues are fixed in Halyard 1.34.
 
 # Steps
 

--- a/guides/user/plugins/deploy-example.md
+++ b/guides/user/plugins/deploy-example.md
@@ -16,7 +16,7 @@ sidebar:
 
 # Caveats with Halyard 1.33
 
-* Halyard does not update the plugin configuration when you run `hal plugins edit`. You must manually update the `.hal\config` entry.
+* Halyard does not update the plugin configuration when you run `hal plugins edit`. You must manually update the `.hal/config` entry.
 * Halyard does not tell Orca where to look for the plugin. Navigate to `.hal/default/profiles` and create an `orca-local.yml` file with this content:
 
 	```yaml
@@ -28,9 +28,9 @@ These issues are fixed in Halyard 1.34.
 
 1. Download  [`RandomWaitStageIndex.js`](https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/releases/download/v1.0.16/RandomWaitStageIndex.js) and move the file to a publicly accessible location that supports CORs, such as an AWS S3 bucket.
 
-1. Create the `orca-local.yml` file (see above)
+1. Create the `orca-local.yml` file (see above).
 
-1. Configure the plugin repository and redeploy Spinnaker
+1. Configure the plugin repository and redeploy Spinnaker.
 
 	```shell
 	hal plugins repository add spinnaker-plugin-examples \
@@ -38,7 +38,7 @@ These issues are fixed in Halyard 1.34.
 	hal deploy apply
 	```
 
-1. Add the pf4jStagePlugin
+1. Add the pf4jStagePlugin.
 
 	```shell
 	hal plugins add Armory.RandomWaitPlugin \
@@ -84,7 +84,7 @@ These issues are fixed in Halyard 1.34.
 	```
 
 
-1. Redeploy Spinnaker
+1. Redeploy Spinnaker.
 
 	```shell
 	hal deploy apply

--- a/guides/user/plugins/user-guide.md
+++ b/guides/user/plugins/user-guide.md
@@ -33,17 +33,17 @@ Define plugins in a file called `plugins.json`. This guide uses the [file](https
 ```json
 [
  {
-   "id": <unique-plugin-id>,
-   "description": <description>,
-   "provider": <provider>,
+   "id": "<unique-plugin-id>",
+   "description": "<description>",
+   "provider": "<provider>",
    "releases": [
 	 {
-	   "version": <version>,
-	   "date": <date>,
-	   "requires": <comma-delimited-list-of-spinnaker-services>,
-	   "sha512sum": <checksum>,
-	   "state": <state>,
-	   "url": <complete-url-to-bundle-zip-file>
+	   "version": "<version>",
+	   "date": "<date>",
+	   "requires": "<comma-delimited-list-of-spinnaker-services>",
+	   "sha512sum": "<checksum>",
+	   "state": "<state>",
+	   "url": "<complete-url-to-bundle-zip-file>"
 	 }
    ]
  }
@@ -55,7 +55,7 @@ Define plugins in a file called `plugins.json`. This guide uses the [file](https
   {
     "id": "Armory.RandomWaitPlugin",
     "description": "An example of a PF4J-based plugin that provides a new stage.",
-    "provider": "https://github.com/claymccoy",
+    "provider": "https://github.com/spinnaker-plugin-examples",
     "releases": [
       {
           "version": "1.0.17",
@@ -66,7 +66,7 @@ Define plugins in a file called `plugins.json`. This guide uses the [file](https
           "url": "https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/releases/download/v1.0.17/pf4jStagePlugin-v1.0.17.zip"
         },
       {
-        "version": "1.0.17",
+        "version": "1.0.16",
         "date": "2020-02-26T18:42:44.793Z",
         "requires": "orca>=0.0.0,deck>=0.0.0",
         "sha512sum": "0a218278c8f9083f54117983e64ae508c5f21ddfc4dc5e5a6b757d73d61f216407cfa92a42d63ebd01ef80937373c973acc103ef5c758333511f66ec239c9943",
@@ -104,8 +104,8 @@ This guide uses the [file](https://raw.githubusercontent.com/spinnaker-plugin-ex
 ```json
 [
   {
-    "id": <unique-repo-name>,
-    "url": <url-of-plugins.json-file>
+    "id": "<unique-repo-name>",
+    "url": "<url-of-plugins.json-file>"
   }
 ]
 ```
@@ -178,7 +178,7 @@ hal plugins add Armory.RandomWaitPlugin \
     --version=<version>             
 ```
 
-Use `--ui-resource-location=<location-of-plugin-ui-resource>` to configure the frontend portion of the plugin. This parameter may be omitted when the plugin doesn't have a UI component. The `url` must be publicly accessible. It also has to allow for [cross origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) requests.
+Use `--ui-resource-location=<location-of-plugin-ui-resource>` to configure the frontend portion of the plugin. This parameter may be omitted when the plugin doesn't have a UI component. The `url` of the JavaScript application file must be publicly accessible. It also has to allow for [cross origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) requests.
 
 See the command [reference](/reference/halyard/commands/#hal-plugins-add) for the complete list of parameters.
 

--- a/guides/user/plugins/user-guide.md
+++ b/guides/user/plugins/user-guide.md
@@ -1,15 +1,13 @@
 ---
 layout: single
-title:  "Plugin Users Guide"
+title:  "Users Guide"
 sidebar:
   nav: guides
 ---
 
-{% include toc %}
+{% include alpha version="1.19.4" %}
 
-<div class="notice--danger">
-  <strong>Note:</strong> Plugins are an early alpha feature that is under active development and will likely change.
-</div>
+{% include toc %}
 
 In this guide, you add an existing plugin from an [example repository](https://github.com/spinnaker-plugin-examples/examplePluginRepository) to Spinnaker. See the [Plugin Creators Guide](/guides/developer/plugin-creators) for how to create a plugin.
 
@@ -17,8 +15,8 @@ In this guide, you add an existing plugin from an [example repository](https://g
 
 * The plugin is either a [Plugin Framework for Java](https://github.com/pf4j/pf4j)(PF4J) plugin or a Spring plugin
 * The plugin resides in a location that Spinnaker can access
-* You use Spinnaker v1.19 or later
-* You use Halyard v1.32.0 or later to deploy Spinnaker
+* You use Spinnaker v1.19.4 or later
+* You use Halyard v1.34 or later to deploy Spinnaker
 
 # Plugins overview
 
@@ -60,12 +58,20 @@ Define plugins in a file called `plugins.json`. This guide uses the [file](https
     "provider": "https://github.com/claymccoy",
     "releases": [
       {
-        "version": "1.0.16",
+          "version": "1.0.17",
+          "date": "2020-03-25T16:07:51.524Z",
+          "requires": "orca>=0.0.0,deck>=0.0.0",
+          "sha512sum": "17f23cc00a3f931c66b6fe90f69fca3a8221687900163ff54e942be1b05c405bf7250a5be2a9265f7f204ec4f4fcb2afedaebd7c903f2f3c7127c1c6902fdc93",
+          "state": "RELEASE",
+          "url": "https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/releases/download/v1.0.17/pf4jStagePlugin-v1.0.17.zip"
+        },
+      {
+        "version": "1.0.17",
         "date": "2020-02-26T18:42:44.793Z",
         "requires": "orca>=0.0.0,deck>=0.0.0",
         "sha512sum": "0a218278c8f9083f54117983e64ae508c5f21ddfc4dc5e5a6b757d73d61f216407cfa92a42d63ebd01ef80937373c973acc103ef5c758333511f66ec239c9943",
         "state": "RELEASE",
-        "url": "https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/releases/download/v1.0.16/pf4jStagePlugin-v1.0.16.zip"
+        "url": "https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/releases/download/v1.0.16/pf4jStagePlugin-v1.0.17.zip"
       },
       {
         "version": "1.0.15",


### PR DESCRIPTION
Update the Plugin Users Guide to add a page with steps on how to deploy the pf4jStagePlugin. Included are two Halyard 1.33 caveats. Without these, users will encounter errors deploying plugins.

Would like to get this merged for Gardening Days.