### PR TITLE
docs(plugins): Add redirect-from to user and creator guides

### DIFF
--- a/guides/developer/plugin-creators/overview.md
+++ b/guides/developer/plugin-creators/overview.md
@@ -3,6 +3,8 @@ layout: single
 title: "Overview"
 sidebar:
   nav: guides
+redirect-from:
+  - /guides/developer/plugin-creators/
 ---
 
 {% include alpha version="1.19.4" %}

--- a/guides/user/plugins/user-guide.md
+++ b/guides/user/plugins/user-guide.md
@@ -3,6 +3,8 @@ layout: single
 title:  "Users Guide"
 sidebar:
   nav: guides
+redirect_from:
+  - /guides/user/plugin-users/
 ---
 
 {% include alpha version="1.19.4" %}


### PR DESCRIPTION
Add redirect-from in front matter to redirect from old page to new page.  Google search for "Spinnaker plugins" has results that point to pages that no longer exist. Added redirect-from so users don't get a 404.

The `jekyll-redirect-from` plugin is listed in `_config.yml` but not listed in the Gemfile. Anybody know why? And will Jekyll load the `jekyll-redirect-plugin` if it's not listed in the Gemfile?