### PR TITLE
docs(footer): update footer copyright year

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,5 +17,5 @@
       <li><a href="https://twitter.com/{{ site.twitter.username }}">Twitter</a></li>
     {% endif %}
   </ul>
-  <h4>Copyright © 2019 The Linux Foundation®. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page. Linux is a registered trademark of Linus Torvalds. <a href="http://www.linuxfoundation.org/privacy">Privacy Policy</a> and <a href="http://www.linuxfoundation.org/terms">Terms of Use</a></h4>
+  <h4>Copyright © 2020 The Linux Foundation®. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage">Trademark Usage</a> page. Linux is a registered trademark of Linus Torvalds. <a href="http://www.linuxfoundation.org/privacy">Privacy Policy</a> and <a href="http://www.linuxfoundation.org/terms">Terms of Use</a></h4>
 </div>


### PR DESCRIPTION
Update the footer to say 2020 instead of 2019: https://s.armory.io/OAubEAX8