### PR TITLE
add warning regarding invalid Jinja methods

### DIFF
--- a/reference/artifacts/from-build-triggers.md
+++ b/reference/artifacts/from-build-triggers.md
@@ -87,7 +87,7 @@ customFormat=true
 
 ### Warning
 
-Spinnaker > 1.15.x uses Jinjava 2.2.3 which does not support methods such as `tojson`. Make sure to use supported Jina syntax
+Spinnaker > 1.15.x uses Jinjava 2.2.3 which does not support methods such as `tojson`. Make sure to use supported Jinja syntax
 
 ## Supplied templates
 

--- a/reference/artifacts/from-build-triggers.md
+++ b/reference/artifacts/from-build-triggers.md
@@ -85,6 +85,10 @@ messageFormat=custom-jar
 customFormat=true
 ```
 
+### Warning
+
+Spinnaker > 1.15.x uses Jinjava 2.2.3 which does not support methods such as `tojson`. Make sure to use supported Jina syntax
+
 ## Supplied templates
 
 The templates that are supplied with Spinnaker can be found in the


### PR DESCRIPTION
There are quite a few examples on how to create dynamic artifacts using `tojson` Jinja method: 
https://github.com/spinnaker/spinnaker/issues/4675
https://github.com/spinnaker/spinnaker/issues/3401

Unfortunately, these snippets no longer work due to Jinjava changes since `1.15`:
https://github.com/spinnaker/orca/pull/2921

We should add warning so folks are aware and can potentially use a workaround:
https://github.com/spinnaker/spinnaker/issues/5012