### PR TITLE
removed unnecesary deploy apply step based on PR1800

### DIFF
--- a/setup/install/providers/aws/aws-ec2.md
+++ b/setup/install/providers/aws/aws-ec2.md
@@ -97,7 +97,6 @@ After the AWS IAM user, roles, policies and trust relationship have been set up,
 1. Access the Halyard Pod.
 2. Add the configurations for AWS provider with `hal` command. Please check [hal config provider AWS](https://www.spinnaker.io/reference/halyard/commands/#hal-config-provider-aws).
 3. Enable the AWS provider `hal config provider aws enable`.
-4. Apply the configurations to Spinnaker `hal deploy apply`.
 
 ### Configure Halyard to use AccessKeys (if configured)
 


### PR DESCRIPTION
Reopened based on this PR [1800](https://github.com/spinnaker/spinnaker.github.io/pull/1800)
Removed unnecessary step from section Halyard Configurations. 
Applying the command is done but not at this stage. Maybe we can make a note somewhere if you want that the installation steps are a procedure to be followed from beggining to end.
