### PR TITLE
feat(docs): update references to removed appengine and artifacts feature flags

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -563,47 +563,7 @@ reference:
         url: /reference/providers/kubernetes-v2/
       - title: Oracle Cloud
         url: /reference/providers/oracle/
-  - title: Artifacts (Standard UI)
-    collapsed: true
-    children:
-      - title: Overview
-        url: /reference/artifacts/
-      - title: In Pipelines
-        url: /reference/artifacts/in-pipelines/
-      - title: From Build Triggers
-        url: /reference/artifacts/from-build-triggers/
-      - title: In Kubernetes (Manifest Based)
-        url: /reference/artifacts/in-kubernetes-v2/
-      - title: In Google App Engine
-        url: /reference/artifacts/in-appengine/
-      - title: Types of Artifacts
-        collapsed: true
-        children:
-          - title: Overview
-            url: /reference/artifacts/types/overview/
-          - title: Docker Image
-            url: /reference/artifacts/types/docker-image/
-          - title: Embedded Base64
-            url: /reference/artifacts/types/embedded-base64/
-          - title: GCS Object
-            url: /reference/artifacts/types/gcs-object/
-          - title: S3 Object
-            url: /reference/artifacts/types/s3-object/
-          - title: Git Repo
-            url: /reference/artifacts/types/git-repo/
-          - title: GitHub File
-            url: /reference/artifacts/types/github-file/
-          - title: GitLab File
-            url: /reference/artifacts/types/gitlab-file/
-          - title: Bitbucket File
-            url: /reference/artifacts/types/bitbucket-file/
-          - title: HTTP File
-            url: /reference/artifacts/types/http-file/
-          - title: Kubernetes Object
-            url: /reference/artifacts/types/kubernetes-object/
-          - title: Oracle Object
-            url: /reference/artifacts/types/oracle-object/
-  - title: Artifacts (New UI)
+  - title: Artifacts
     collapsed: true
     children:
       - title: Overview
@@ -647,6 +607,46 @@ reference:
             url: /reference/artifacts-with-artifactsrewrite/types/oracle-object/
           - title: Maven Artifact
             url: /reference/artifacts-with-artifactsrewrite/types/maven-artifact/
+  - title: Artifacts (Legacy UI)
+    collapsed: true
+    children:
+      - title: Overview
+        url: /reference/artifacts/
+      - title: In Pipelines
+        url: /reference/artifacts/in-pipelines/
+      - title: From Build Triggers
+        url: /reference/artifacts/from-build-triggers/
+      - title: In Kubernetes (Manifest Based)
+        url: /reference/artifacts/in-kubernetes-v2/
+      - title: In Google App Engine
+        url: /reference/artifacts/in-appengine/
+      - title: Types of Artifacts
+        collapsed: true
+        children:
+          - title: Overview
+            url: /reference/artifacts/types/overview/
+          - title: Docker Image
+            url: /reference/artifacts/types/docker-image/
+          - title: Embedded Base64
+            url: /reference/artifacts/types/embedded-base64/
+          - title: GCS Object
+            url: /reference/artifacts/types/gcs-object/
+          - title: S3 Object
+            url: /reference/artifacts/types/s3-object/
+          - title: Git Repo
+            url: /reference/artifacts/types/git-repo/
+          - title: GitHub File
+            url: /reference/artifacts/types/github-file/
+          - title: GitLab File
+            url: /reference/artifacts/types/gitlab-file/
+          - title: Bitbucket File
+            url: /reference/artifacts/types/bitbucket-file/
+          - title: HTTP File
+            url: /reference/artifacts/types/http-file/
+          - title: Kubernetes Object
+            url: /reference/artifacts/types/kubernetes-object/
+          - title: Oracle Object
+            url: /reference/artifacts/types/oracle-object/
   - title: Halyard
     collapsed: true
     children:

--- a/guides/tutorials/codelabs/artifactory-to-cf/index.md
+++ b/guides/tutorials/codelabs/artifactory-to-cf/index.md
@@ -6,10 +6,6 @@
 ---
 
  {% include toc %}
- 
-> This codelab assumes that you have enabled the `artifactsRewrite` feature flag. In `~/.hal/$DEPLOYMENT/profiles/settings-local.js` (where `$DEPLOYMENT` is typically `default`), add:
->
-> `window.spinnakerSettings.feature.artifactsRewrite = true;`
 
 In this codelab, you will deploy an artifact to Cloud Foundry via a Spinnaker pipeline. The pipeline is triggered by an artifact published to a JFrog Artifactory Maven repository or by an app manifest stored in a GitHub repository.
 
@@ -17,6 +13,7 @@ In this codelab, you will deploy an artifact to Cloud Foundry via a Spinnaker pi
 
 This codelab assumes you have the following:
 
+* Artifact support [enabled](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
 * An Artifactory repository configured to accept a Maven artifact&mdash;the JAR for your application
 * A GitHub repository containing a manifest with which to deploy your application
 

--- a/guides/tutorials/codelabs/pubsub-to-appengine/index.md
+++ b/guides/tutorials/codelabs/pubsub-to-appengine/index.md
@@ -90,8 +90,7 @@ We'll need this service account later, so keep these environment variables handy
 
 First, configure your GCS artifact provider.
 
-1. Enable artifiact support:
-`hal config features edit --artifacts true`.
+1. Enable [artifact support](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
 
 2. Enable the GCS artifact provider:
 `hal config artifact gcs enable`

--- a/guides/tutorials/codelabs/pubsub-to-cf/index.md
+++ b/guides/tutorials/codelabs/pubsub-to-cf/index.md
@@ -7,10 +7,6 @@
  
  {% include toc %}
 
-> This codelab assumes that you have enabled the `artifactsRewrite` feature flag. In `~/.hal/$DEPLOYMENT/profiles/settings-local.js` (where `$DEPLOYMENT` is typically `default`), add:
->
-> `window.spinnakerSettings.feature.artifactsRewrite = true;`
- 
 In this codelab, you will deploy an artifact to Cloud Foundry via a Spinnaker pipeline that is triggered by JAR uploads to a Google Cloud Storage (GCS) bucket.
 
 ## Prerequisites
@@ -19,6 +15,7 @@ This codelab assumes you have the following:
 
 1. A billing-enabled Google Cloud Platform (GCP) project.
 1. The `gcloud` CLI tool (installed locally on your computer).
+1. Artifact support [enabled](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
 
 ## 1. Create a GCS Bucket for Artifact Storage
 
@@ -64,10 +61,9 @@ b. Create a key for the service account and download the key in JSON format to y
 
 ## 4. Tell Spinnaker to Use the Pub/Sub Subscription
 
-a. Enable artifact support, then enable the GCS artifact provider:
+a. Enable the GCS artifact provider:
 
   ```
-  $ hal config features edit --artifacts true
   $ hal config artifact gcs enable
   ```
 

--- a/guides/user/pipeline/index.md
+++ b/guides/user/pipeline/index.md
@@ -9,8 +9,8 @@ The pipeline is the key deployment management construct in Spinnaker. Here are
 a few guides to help you get started using pipelines:
 
 * [Managing Pipelines](/guides/user/pipeline/managing-pipelines/)
-* [Triggering Pipelines (Standard Artifacts UI)](/guides/user/pipeline/triggers/)
-* [Triggering Pipelines (New Artifacts UI)](/guides/user/pipeline/triggers-with-artifactsrewrite/)
+* [Triggering Pipelines](/guides/user/pipeline/triggers-with-artifactsrewrite/)
+* [Triggering Pipelines (Legacy Artifacts UI)](/guides/user/pipeline/triggers/)
 * [Pipeline Expressions](/guides/user/pipeline/expressions/)
 * [Searching for Triggered Pipeline Executions](/guides/user/pipeline/searching/)
 * [Managing and Using Pipeline Templates](/guides/user/pipeline/pipeline-templates/)

--- a/guides/user/pipeline/triggers-with-artifactsrewrite/artifactory/index.md
+++ b/guides/user/pipeline/triggers-with-artifactsrewrite/artifactory/index.md
@@ -7,9 +7,6 @@ sidebar:
 
 {% include toc %}
 
-> This guide assumes that you have enabled the `artifactsRewrite` feature flag.
-> See [Prerequisites](#prerequisites).
-
 This guide explains how to add a [JFrog
 Artifactory](https://jfrog.com/artifactory/) trigger to your pipeline.
 
@@ -27,10 +24,7 @@ commands](/reference/halyard/commands/#hal-config-repository-artifactory))
   config artifact maven` Halyard
 commands](/reference/halyard/commands/#hal-config-artifact-maven))
 
-* The `artifactsRewrite` feature flag enabled in Spinnaker. In
-  `~/.hal/$DEPLOYMENT/profiles/settings-local.js` (where `$DEPLOYMENT` is
-  typically `default`), add the line
-  `window.spinnakerSettings.feature.artifactsRewrite = true;`.
+* Artifact support [enabled](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
 
 # Adding an Artifactory Trigger
 

--- a/guides/user/pipeline/triggers-with-artifactsrewrite/gcs/index.md
+++ b/guides/user/pipeline/triggers-with-artifactsrewrite/gcs/index.md
@@ -7,9 +7,6 @@ sidebar:
 
 {% include toc %}
 
-> This guide assumes that you have enabled the `artifactsRewrite` feature flag.
-> See [Prerequisite configuration/setup](#prerequisite-configurationsetup).
-
 This guide explains how to configure Spinnaker to trigger pipelines based on
 changes in a [Google Cloud Storage](https://cloud.google.com/storage/) (GCS)
 bucket, and inject changed GCS objects as [artifacts](/reference/artifacts)
@@ -40,11 +37,8 @@ You need the following:
 * [A running Spinnaker instance](/setup/install/). This guide shows you how
   to configure an existing one to accept GCS messages, and download the files
   referenced by the messages in your pipelines.
-
-* The `artifactsRewrite` feature flag enabled in Spinnaker. In
-  `~/.hal/$DEPLOYMENT/profiles/settings-local.js` (where `$DEPLOYMENT` is
-  typically `default`), add the line
-  `window.spinnakerSettings.feature.artifactsRewrite = true;`.
+  
+* Artifact support [enabled](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).  
 
 At this point, we will configure Pub/Sub, and a GCS artifact account. The
 Pub/Sub messages will be received by Spinnaker whenever a file is uploaded or

--- a/guides/user/pipeline/triggers-with-artifactsrewrite/github/index.md
+++ b/guides/user/pipeline/triggers-with-artifactsrewrite/github/index.md
@@ -7,9 +7,6 @@ sidebar:
 
 {% include toc %}
 
-> This guide assumes that you have enabled the `artifactsRewrite` feature flag.
-> See [Prerequisite configuration/setup](#prerequisite-configurationsetup).
-
 This guide explains how to configure Spinnaker to trigger pipelines based on
 commits to a [GitHub](https://github.com) repository and inject changed GitHub
 files as [artifacts](/reference/artifacts) into a pipeline.
@@ -35,11 +32,8 @@ You need the following:
 
 * [A running Spinnaker instance](/setup/install/). This guide shows you how to
   update it to accept messages from GitHub.
-
-* The `artifactsRewrite` feature flag enabled in Spinnaker. In
-  `~/.hal/$DEPLOYMENT/profiles/settings-local.js` (where `$DEPLOYMENT` is
-  typically `default`), add the line
-  `window.spinnakerSettings.feature.artifactsRewrite = true;`.
+  
+* Artifact support [enabled](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).  
 
 
 At this point, we will configure GitHub webhooks and a GitHub artifact account.

--- a/guides/user/pipeline/triggers-with-artifactsrewrite/index.md
+++ b/guides/user/pipeline/triggers-with-artifactsrewrite/index.md
@@ -7,12 +7,6 @@ sidebar:
 
 {% include toc %}
 
-> The guides listed below assume that you have enabled the `artifactsRewrite`
-> feature flag. In `~/.hal/$DEPLOYMENT/profiles/settings-local.js` (where
-> `$DEPLOYMENT` is typically `default`), add:
->
-> `window.spinnakerSettings.feature.artifactsRewrite = true;`
-
 A pipeline trigger defines when to automatically run a pipeline. There are many
 types of triggers available: Jenkins jobs, webhooks, CRON jobs, even other
 pipelines. Adding a trigger to your pipeline means that the pipeline runs each

--- a/guides/user/pipeline/triggers-with-artifactsrewrite/jenkins/index.md
+++ b/guides/user/pipeline/triggers-with-artifactsrewrite/jenkins/index.md
@@ -7,9 +7,6 @@ sidebar:
 
 {% include toc %}
 
-> This guide assumes that you have enabled the `artifactsRewrite` feature flag.
-> See [Prerequisites](#prerequisites).
-
 This guide explains how to add a [Jenkins](https://jenkins.io/){:target="\_blank"}
 trigger to your pipeline.
 
@@ -17,10 +14,7 @@ trigger to your pipeline.
 
 * [Set up Jenkins](/setup/ci/jenkins/) as a continuous integration system in
     your Spinnaker deployment.
-* Enable the `artifactsRewrite` feature flag in Spinnaker. In
-  `~/.hal/$DEPLOYMENT/profiles/settings-local.js` (where `$DEPLOYMENT` is
-  typically `default`), add the line
-  `window.spinnakerSettings.feature.artifactsRewrite = true;`.
+* Enable [artifact support](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).  
 
 ## Adding a Jenkins trigger
 

--- a/guides/user/pipeline/triggers-with-artifactsrewrite/pubsub/index.md
+++ b/guides/user/pipeline/triggers-with-artifactsrewrite/pubsub/index.md
@@ -7,9 +7,6 @@ sidebar:
 
 {% include toc %}
 
-> This guide assumes that you have enabled the `artifactsRewrite` feature flag.
-> See [Prerequisites](#prerequisites).
-
 In order to programatically trigger pipelines one can configure Spinnaker to
 subscribe and listen to a Pub/Sub topic and push messages to the configured
 topic. This can be used to trigger pipelines during CI jobs, from the command line,
@@ -24,10 +21,7 @@ Only Google Pub/Sub is supported. See the instructions
 
 ## Prerequisites
 
-* Enable the `artifactsRewrite` feature flag in Spinnaker. In
-  `~/.hal/$DEPLOYMENT/profiles/settings-local.js` (where `$DEPLOYMENT` is
-  typically `default`), add the line
-  `window.spinnakerSettings.feature.artifactsRewrite = true;`.
+* Artifact support [enabled](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
 
 ## Adding a Pub/Sub trigger to a pipeline
 

--- a/guides/user/pipeline/triggers-with-artifactsrewrite/webhooks/index.md
+++ b/guides/user/pipeline/triggers-with-artifactsrewrite/webhooks/index.md
@@ -7,9 +7,6 @@ sidebar:
 
 {% include toc %}
 
-> This guide assumes that you have enabled the `artifactsRewrite` feature flag.
-> See [Prerequisites](#prerequisites).
-
 In order to programatically trigger pipelines you can send a `POST` call to
 Spinnaker at a preconfigured endpoint. You can use this to trigger pipelines
 when a CI job finishes, from the command line, or from a third-party system.
@@ -24,10 +21,7 @@ If you're triggering from a *GitHub* webhook, see the instructions
 
 ## Prerequisites
 
-* Enable the `artifactsRewrite` feature flag in Spinnaker. In
-  `~/.hal/$DEPLOYMENT/profiles/settings-local.js` (where `$DEPLOYMENT` is
-  typically `default`), add the line
-  `window.spinnakerSettings.feature.artifactsRewrite = true;`.
+* Artifact support [enabled](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
 
 ## Adding a webhook trigger to a pipeline
 

--- a/reference/artifacts-with-artifactsrewrite/index.md
+++ b/reference/artifacts-with-artifactsrewrite/index.md
@@ -7,12 +7,6 @@ sidebar:
 
 {% include toc %}
 
-> The pages in this section assume that you have enabled the `artifactsRewrite`
-> feature flag. In `~/.hal/$DEPLOYMENT/profiles/settings-local.js` (where
-> `$DEPLOYMENT` is typically `default`), add:
->
-> `window.spinnakerSettings.feature.artifactsRewrite = true;`
-
 A Spinnaker artifact is a named JSON object that refers to an external resource.
 
 Spinnaker supports a wide range of providers. An artifact can reference any of many different external resources, such as&#8230;
@@ -27,6 +21,16 @@ Each of these could be fetched using a URI and used within a pipeline, but a URI
 To incorporate metadata such as this along with the resource's URI, Spinnaker artifacts follow a particular specification that includes the human-readable name of the artifact, its URI, and any other applicable metadata. This is called "artifact decoration". Every Spinnaker artifact--whether supplied to a pipeline, accessed within a pipeline, or produced by a pipeline--follows this specification.
 
 Keep in mind that the artifact in Spinnaker is a _reference_ to an external resource--it is not the resource itself. The resource itself could be of any type supported by Spinnaker; the artifact is the named JSON object that contains information about the resource.
+
+## Enabling artifact support
+
+If using a version of Spinnaker prior to 1.20, enable support for the standard artifacts UI:
+
+```bash
+hal config features edit --artifacts-rewrite true
+```
+
+If using a version of Spinnaker greater than or equal to 1.20, support for the standard artifacts UI is enabled by default.
 
 ## The artifact format
 

--- a/reference/artifacts-with-artifactsrewrite/index.md
+++ b/reference/artifacts-with-artifactsrewrite/index.md
@@ -30,7 +30,7 @@ If using a version of Spinnaker prior to 1.20, enable support for the standard a
 hal config features edit --artifacts-rewrite true
 ```
 
-If using a version of Spinnaker greater than or equal to 1.20, support for the standard artifacts UI is enabled by default.
+If using Spinnaker 1.20 or later, support for the standard artifacts UI is enabled by default.
 
 ## The artifact format
 

--- a/reference/artifacts/index.md
+++ b/reference/artifacts/index.md
@@ -5,6 +5,10 @@ sidebar:
   nav: reference
 ---
 
+> This section refers to the legacy artifacts UI, which is scheduled for removal
+> in release 1.21. Please refer to the [standard artifacts guide](/reference/artifacts-with-artifactsrewrite)
+> instead.
+
 {% include toc %}
 
 In Spinnaker, an artifact is an object that references an external resource. That resource could be…

--- a/reference/halyard/custom.md
+++ b/reference/halyard/custom.md
@@ -56,12 +56,12 @@ their services by checking `~/.hal/$DEPLOYMENT/history/service-profiles.yml`.
 
 To supply custom settings or new values that override generated settings for the
 Deck UI, you can place them in a file called `settings-local.js`. For
-example, to enable the `artifactsRewrite` feature flag, you can create the
+example, to enable the `chaosMonkey` feature flag, you can create the
 following file:
 
 __`~/.hal/default/profiles/settings-local.js`:__
 ```js
-window.spinnakerSettings.feature.artifactsRewrite = true;
+window.spinnakerSettings.feature.chaosMonkey = true;
 ```
 
 ## Custom Service Settings

--- a/setup/artifacts/bitbucket.md
+++ b/setup/artifacts/bitbucket.md
@@ -26,11 +26,13 @@ account with the needed credentials to read your artifact.
 
 1. Collect the `$USERNAME_PASSWORD_FILE` value returned from the
    [prerequisites](#prerequisites) section above.
+   
+2. Enable [artifact support](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
 
-2. Make sure that artifact support is enabled:
+
+2. Enable the Bitbucket artifact provider:
 
    ```bash
-   hal config features edit --artifacts true
    hal config artifact bitbucket enable
    ```
 

--- a/setup/artifacts/gcs.md
+++ b/setup/artifacts/gcs.md
@@ -67,11 +67,7 @@ SERVICE_ACCOUNT_DEST=~/.gcp/gcs-artifacts-account.json
 ARTIFACT_ACCOUNT_NAME=my-gcs-artifact-account
 ```
 
-First, make sure that artifact support is enabled:
-
-```bash
-hal config features edit --artifacts true
-```
+First, enable [artifact support](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
 
 Next, add an artifact account:
 

--- a/setup/artifacts/github.md
+++ b/setup/artifacts/github.md
@@ -38,10 +38,11 @@ TOKEN_FILE=
 ARTIFACT_ACCOUNT_NAME=my-github-artifact-account
 ```
 
-First, make sure that artifact support is enabled:
+First, enable [artifact support](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
+
+Next, enable the GitHub artifact provider:
 
 ```bash
-hal config features edit --artifacts true
 hal config artifact github enable
 ```
 

--- a/setup/artifacts/gitlab.md
+++ b/setup/artifacts/gitlab.md
@@ -36,10 +36,11 @@ TOKEN_FILE=
 ARTIFACT_ACCOUNT_NAME=my-gitlab-artifact-account
 ```
 
-First, make sure that artifact support is enabled:
+First, enable [artifact support](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
+
+Next, enable the GitLab artifact provider:
 
 ```bash
-hal config features edit --artifacts true
 hal config artifact gitlab enable
 ```
 

--- a/setup/artifacts/http.md
+++ b/setup/artifacts/http.md
@@ -34,14 +34,15 @@ config for this is hidden, and the single account is automatically used.
 1. Collect the `$USERNAME_PASSWORD_FILE` value returned from the
    [prerequisites](#prerequisites) section above.
 
-2. Make sure that artifact support is enabled:
+2. Enable [artifact support](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
+
+3. Enable the HTTP artifact provider:
 
    ```bash
-   hal config features edit --artifacts true
    hal config artifact http enable
    ```
 
-3. Add an artifact account:
+4. Add an artifact account:
 
    ```bash
    hal config artifact http account add my-http-account \

--- a/setup/artifacts/maven.md
+++ b/setup/artifacts/maven.md
@@ -19,10 +19,11 @@ that reads the data.
 
 ## Edit your artifact settings
 
-1. Make sure that artifact support is enabled:
+1. Enable [artifact support](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
+
+1. Enable the Maven artifact provider:
 
    ```bash
-   hal config features edit --artifacts true
    hal config artifact maven enable
    ```
 

--- a/setup/artifacts/oracle.md
+++ b/setup/artifacts/oracle.md
@@ -49,11 +49,7 @@ If you have enabled [Oracle Cloud provider](/setup/install/providers/oracle/) in
    
 ## Add Oracle Object Storage Artifact to Spinnaker
 
-First, make sure that artifact support is enabled:
-
-```bash
-hal config features edit --artifacts true
-```
+First, enable [artifact support](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
 
 Next, add an artifact account:
 

--- a/setup/artifacts/s3.md
+++ b/setup/artifacts/s3.md
@@ -20,15 +20,15 @@ API_REGION=
 REGION=
 ARTIFACT_ACCOUNT_NAME=my-s3-account
 ```
+1. Enable [artifact support](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
 
-1. Make sure that artifact support is enabled:
+2. Enable the S3 artifact provider:
 
    ```bash
-   hal config features edit --artifacts true
    hal config artifact s3 enable
    ```
 
-2. Add an artifact account:
+3. Add an artifact account:
 
    ```bash
    hal config artifact s3 account add my-s3-account \

--- a/setup/install/providers/appengine.md
+++ b/setup/install/providers/appengine.md
@@ -120,18 +120,10 @@ fetch your tar archive, untar it, and then deploy the code to App Engine.
 ### Deploying from Google Container Registry URL
 
 Spinnaker supports deploying Docker containers on the App Engine Flex runtime from images built and stored
-in Google Container Registry from just a gcr.io URL.  This feature is currently flagged because it is still quite new.
+in Google Container Registry from just a gcr.io URL.
 
-In order to enable this feature, set the flag with Halyard like so:
-
-```bash
-hal config features edit --appengine-container-image-url-deployments true
-```
-
-After doing this you'll find an option in the Create Server Group modal in Deck to use a Container Image as a
-deployment's Source Type.
-
-Selecting the Container Image option reveals a textbox that can then be used to specify the gcr.io URL.  Alternatively
+You'll find an option in the Create Server Group modal in Deck to use a Container Image as a
+deployment's Source Type. Selecting the Container Image option reveals a textbox that can then be used to specify the gcr.io URL.  Alternatively
 you can use an Artifact as the source of the container image URL.
 
 ## Next steps

--- a/setup/install/providers/appengine.md
+++ b/setup/install/providers/appengine.md
@@ -122,9 +122,9 @@ fetch your tar archive, untar it, and then deploy the code to App Engine.
 Spinnaker supports deploying Docker containers on the App Engine Flex runtime from images built and stored
 in Google Container Registry from just a gcr.io URL.
 
-You'll find an option in the Create Server Group modal in Deck to use a Container Image as a
-deployment's Source Type. Selecting the Container Image option reveals a textbox that can then be used to specify the gcr.io URL.  Alternatively
-you can use an Artifact as the source of the container image URL.
+You'll find an option in the Create Server Group dialog in Deck to use a **Container Image** as a
+deployment's **Source Type**. Selecting the **Container Image** option reveals a textbox that can then be used to specify the gcr.io URL.  Alternatively
+you can use an **Artifact** as the source of the container image URL.
 
 ## Next steps
 

--- a/setup/install/providers/kubernetes-v2/aws-eks.md
+++ b/setup/install/providers/kubernetes-v2/aws-eks.md
@@ -116,8 +116,9 @@ users:
 ```bash
 hal config provider kubernetes enable
 hal config provider kubernetes account add ${MY_K8_ACCOUNT} --provider-version v2 --context $(kubectl config current-context)
-hal config features edit --artifacts true
 ```
+
+Finally, enable [artifact support](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
 
 ## Launch and Configure Amazon EKS Worker Nodes
 

--- a/setup/install/providers/kubernetes-v2/index.md
+++ b/setup/install/providers/kubernetes-v2/index.md
@@ -209,11 +209,7 @@ hal config provider kubernetes account add my-k8s-v2-account \
     --context $CONTEXT
 ```
 
-You'll also need to run
-
-```bash
-hal config features edit --artifacts true
-```
+Finally, enable [artifact support](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
 
 ## Advanced account settings
 

--- a/setup/install/providers/kubernetes-v2/oke/index.md
+++ b/setup/install/providers/kubernetes-v2/oke/index.md
@@ -30,9 +30,10 @@ hal config provider kubernetes account add my-k8s-v2-acct \
     --provider-version v2 \
     --context $(kubectl config current-context)
 ```
-Enable the Kubernetes provider and artifacts feature:
+Enable the Kubernetes provider:
 
 ```bash
 hal config provider kubernetes enable
-hal config features edit --artifacts true
 ```
+
+Finally, enable [artifact support](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).


### PR DESCRIPTION
- feat(appengine): remove reference to removed feature flag

  We [removed the long-unused `appengineContainerImageUrlDeployments` from Halyard](https://github.com/spinnaker/halyard/pull/1615); let's update the corresponding documentation to clarify that this flag is no longer needed.

- feat(artifacts): update instructions for enabling artifacts

  As of Spinnaker 1.20, the standard ("rewrite") artifacts experience will be enabled by default. Let's re-label the previous "Standard" artifacts experience to "Legacy," move its section under the now-default artifacts documentation section in the nav, and replace all instructions for enabling artifacts with a reference to a new Enabling Artifact Support section. Per the [RFC](https://github.com/spinnaker/governance/blob/master/rfc/legacy_artifacts_ui_removal.md), we can safely remove all legacy artifacts documentation after release 1.23, when no supported release will include the legacy artifacts experience.