### PR TITLE
docs(cleanup) Remove reference to stale AWS install guide

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -49,8 +49,6 @@ setup:
             children:
               - title: Overview
                 url: /setup/install/providers/aws/
-              - title: EC2
-                url: /setup/install/providers/aws/aws-ec2/
               - title: ECS
                 url: /setup/install/providers/aws/aws-ecs/
           - title: Azure

--- a/setup/install/providers/aws/index.md
+++ b/setup/install/providers/aws/index.md
@@ -25,6 +25,5 @@ how they are configured in AWS.
 
 That being said, below are some ways to configure Amazon Web Services (AWS) Cloud Provider. You may choose one or more based on your preferences
 
-* [Amazon Elastic Compute Cloud (EC2)](/setup/install/providers/aws/aws-ec2/) - - Use this option, if you want to manage [EC2 Instances](https://aws.amazon.com/ec2/) via Spinnaker
 * [Amazon Elastic Container Service (ECS)](/setup/install/providers/aws/aws-ecs/) - Use this option, if you want to manage containers in [Amazon ECS](https://aws.amazon.com/ecs/)
 * [Amazon Elastic Kubernetes Service (EKS)](/setup/install/providers/kubernetes-v2/aws-eks/) - Use this option, if you want to manage containers in [Amazon EKS](https://aws.amazon.com/eks/). This option uses [Kubernetes V2 (manifest based) Clouddriver](/setup/install/providers/kubernetes-v2)

--- a/setup/install/providers/kubernetes-v2/aws-eks.md
+++ b/setup/install/providers/kubernetes-v2/aws-eks.md
@@ -3,6 +3,8 @@ layout: single
 title:  "Set up a Kubernetes v2 provider for Amazon EKS"
 sidebar:
   nav: setup
+redirect_from: 
+  - /setup/install/providers/aws/aws-ec2/ 
 ---
 
 {% include toc %}


### PR DESCRIPTION
The EKS guide is already in the navigation menu, and is also referenced in setup/install/providers/aws/index.md (file in this PR).