### PR TITLE
feat(plugins): signal that --ui-resource-location will be unneeded in…

### DIFF
--- a/guides/user/plugins/deploy-example.md
+++ b/guides/user/plugins/deploy-example.md
@@ -24,6 +24,8 @@ sidebar:
     spinnaker.extensibility.plugins-root-path: /opt/orca/plugins
 	```
 These issues are fixed in Halyard 1.34.
+* Prior to Spinnaker 1.20.0 and pf4jStagePlugin 1.1.3, plugin users needed to upload their UI plugin bundle to a publicly-accessible static asset server
+  and point to that resource using the `--ui-resource-location` Halyard flag. You may ignore those instructions below if you are using Spinnaker >= 1.20.0 and pf4jStagePlugin >= 1.1.3.
 
 # Steps
 

--- a/guides/user/plugins/user-guide.md
+++ b/guides/user/plugins/user-guide.md
@@ -182,6 +182,8 @@ hal plugins add Armory.RandomWaitPlugin \
 
 Use `--ui-resource-location=<location-of-plugin-ui-resource>` to configure the frontend portion of the plugin. This parameter may be omitted when the plugin doesn't have a UI component. The `url` of the JavaScript application file must be publicly accessible. It also has to allow for [cross origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) requests.
 
+Users on Spinnaker 1.20.0 or later trying to install pf4jStagePlugin on 1.1.3 or later will not need to configure the `--ui-resource-location` parameter.
+
 See the command [reference](/reference/halyard/commands/#hal-plugins-add) for the complete list of parameters.
 
 ## Configure the plugin


### PR DESCRIPTION
… Spinnaker 1.20.0

These notes are inadequate and will need to be updated once Spinnaker 1.20.0 is actually out, but it's a signal of what's to come. 

In order to omit the `--ui-resource-location` flag from your Hal config, you'll need `pf4jStagePlugin@1.1.3`, but that version requires a change in Orca that won't arrive until Spinnaker 1.20.0.  