### PR TITLE
feat(docs): consistent naming of the Kubernetes provider

### DIFF
--- a/community/gardening/dev-environment.md
+++ b/community/gardening/dev-environment.md
@@ -155,7 +155,6 @@ _The instructions for this method are in beta. Pull requests welcome!_
     accounts:
       name: kubernetes
       requiredMembership: []
-      providerVersion: V2
       permissions: []
       dockerRegistries: []
       configureImagePullSecrets: true

--- a/guides/developer/crd-extensions.md
+++ b/guides/developer/crd-extensions.md
@@ -22,7 +22,7 @@ It also exists as an explanation of certain code paths within Spinnaker which in
 
 Developers who want to implement these features will have to build their own layered version
 of [Clouddriver](https://github.com/spinnaker/clouddriver) -
-  see Adam Jorden's [blog post](https://blog.spinnaker.io/scaling-spinnaker-at-netflix-custom-features-and-packaging-e78536d38040) - and should be familiar with the [Kubernetes V2 provider](/reference/providers/kubernetes-v2) and writing code for Clouddriver.
+  see Adam Jorden's [blog post](https://blog.spinnaker.io/scaling-spinnaker-at-netflix-custom-features-and-packaging-e78536d38040) - and should be familiar with the [Kubernetes provider](/reference/providers/kubernetes-v2) and writing code for Clouddriver.
 
 ## Custom Handlers
 

--- a/guides/index.md
+++ b/guides/index.md
@@ -33,5 +33,5 @@ The following types of user guides are included:
   - [Pipelines](/guides/user/pipeline/)
   - [Tagging](/guides/user/tagging/)
   - [Custom instance links](/guides/user/instance-links/)
-  - [Kubernetes \(manifest based\)](/guides/user/kubernetes-v2/deploy-manifest/)
+  - [Kubernetes](/guides/user/kubernetes-v2/deploy-manifest/)
   - [Automated canary analysis \(Kayenta\)](/guides/user/canary/)

--- a/guides/tutorials/codelabs/kubernetes-v2-source-to-prod/index.md
+++ b/guides/tutorials/codelabs/kubernetes-v2-source-to-prod/index.md
@@ -1,6 +1,6 @@
 ---
 layout: single
-title:  "Kubernetes Source To Prod (Manifest Based)"
+title:  "Kubernetes Source To Prod"
 sidebar:
   nav: guides
 redirect_from: /guides/tutorials/codelabs/kubernetes-source-to-prod/
@@ -112,12 +112,10 @@ Now we will register both contexts with Spinnaker.
 
 ```bash
 hal config provider kubernetes account add prod-demo \
-  --context $PROD_CONTEXT \
-  --provider-version v2
+  --context $PROD_CONTEXT
 
 hal config provider kubernetes account add staging-demo \
-  --context $STAGING_CONTEXT \
-  --provider-version v2
+  --context $STAGING_CONTEXT
 ```
 
 ### Configure GitHub artifact credentials

--- a/guides/tutorials/codelabs/oracle-kubernetes-source-to-prod/index.md
+++ b/guides/tutorials/codelabs/oracle-kubernetes-source-to-prod/index.md
@@ -1,6 +1,6 @@
 ---
 layout: single
-title:  "Continuous Delivery to Kubernetes on Oracle (Manifest Based)"
+title:  "Continuous Delivery to Kubernetes on Oracle"
 sidebar:
   nav: guides
 ---
@@ -121,7 +121,7 @@ Create a new pipeline by navigating to the PIPELINES tab and clicking the *New* 
 
 ### Set up Deploy stage
 
-There are multiple ways to deploy Kubernetes manifests using the Kubernetes Provider V2.  More details can be found in this [Deploying Kubernetes Manifests](/guides/user/kubernetes-v2/deploy-manifest/) guide.
+There are multiple ways to deploy Kubernetes manifests using the Kubernetes provider.  More details can be found in this [Deploying Kubernetes Manifests](/guides/user/kubernetes-v2/deploy-manifest/) guide.
 
 It is preferred to use artifacts as manifests.  However, in this tutorial, the manifest is supplied statically to a pipeline as text for simplicity.
 

--- a/guides/user/applications/index.md
+++ b/guides/user/applications/index.md
@@ -25,7 +25,7 @@ are going to deploy (typically a microservice). It includes...
 When you first access a new instance of Spinnaker you might notice that there
 are already several applications visible when you click the **Applications** tab.
 This happens if you install Spinnaker on an existing Kubernetes cluster, using
-the [Kubernetes V1 provider](/setup/providers/kubernetes/). These applications
+the [Kubernetes provider](/reference/providers/kubernetes-v2/). These applications
 are derived from existing infrastructure.
 
 **Don't delete any of them**.

--- a/guides/user/kubernetes-v2/automated-rollbacks/index.md
+++ b/guides/user/kubernetes-v2/automated-rollbacks/index.md
@@ -1,6 +1,6 @@
 ---
 layout: single
-title:  "Configure Automated Rollbacks in the Kubernetes Provider V2"
+title:  "Configure Automated Rollbacks in the Kubernetes Provider"
 sidebar:
   nav: guides
 ---

--- a/guides/user/kubernetes-v2/best-practices/index.md
+++ b/guides/user/kubernetes-v2/best-practices/index.md
@@ -1,13 +1,13 @@
 ---
 layout: single
-title:  "Best Practices for the Kubernetes Provider V2"
+title:  "Best Practices for the Kubernetes Provider"
 sidebar:
   nav: guides
 ---
 
 {% include toc %}
 
-The Kubernetes Provider V2 enables a wide variety of ways to deploy your
+The Kubernetes provider enables a wide variety of ways to deploy your
 manifests into Kubernetes clusters. This page provides best-practices for doing
 so.
 

--- a/guides/user/kubernetes-v2/deploy-manifest/index.md
+++ b/guides/user/kubernetes-v2/deploy-manifest/index.md
@@ -8,7 +8,7 @@ sidebar:
 {% include toc %}
 
 This guide shows the basics of how to deploy a Kubernetes manifest using the
-[Kubernetes Provider V2](/setup/install/providers/kubernetes-v2).
+[Kubernetes provider](/setup/install/providers/kubernetes-v2).
 
 There are two main steps:
 
@@ -39,7 +39,7 @@ from the stage selector:
 %}
 
 > :warning: Don't select the regular __Deploy__ stage; it deploys more
-> opinionated "Server Groups" using another provider (including Kubernetes V1).
+> opinionated "Server Groups" using other providers.
 
 ### Specify manifests statically
 

--- a/guides/user/kubernetes-v2/index.md
+++ b/guides/user/kubernetes-v2/index.md
@@ -1,19 +1,18 @@
 ---
 layout: single
-title:  "Kubernetes (Manifest Based)"
+title:  "Kubernetes"
 sidebar:
   nav: guides
 ---
 
-The following is a list of guides to help you use the Kubernetes V2 provider,
-also known as the manifest-based Kubernetes provider.
+The following is a list of guides to help you use the Kubernetes provider.
 
 * [Deploy Kubernetes Manifests](/guides/user/kubernetes-v2/deploy-manifest/)
 * [Deploy Helm Charts](/guides/user/kubernetes-v2/deploy-helm/)
 * [Use Kustomize for Manifests](/guides/user/kubernetes-v2/kustomize-manifests/)
-* [Best Practices for the Kubernetes Provider V2](/guides/user/kubernetes-v2/best-practices/)
+* [Best Practices for the Kubernetes Provider](/guides/user/kubernetes-v2/best-practices/)
 * [Parameterize Kubernetes Manifests](/guides/user/kubernetes-v2/parameterize-manifests/)
-* [Configure Automated Rollbacks in the Kubernetes Provider V2](/guides/user/kubernetes-v2/automated-rollbacks/)
+* [Configure Automated Rollbacks in the Kubernetes Provider](/guides/user/kubernetes-v2/automated-rollbacks/)
 * [Annotation-Driven UI](/guides/user/kubernetes-v2/annotations-ui/)
 * [Patch Kubernetes Manifests](/guides/user/kubernetes-v2/patch-manifest/)
 * [Manage Traffic](/guides/user/kubernetes-v2/traffic-management/)

--- a/guides/user/kubernetes-v2/patch-manifest/index.md
+++ b/guides/user/kubernetes-v2/patch-manifest/index.md
@@ -7,7 +7,7 @@ sidebar:
 
 {% include toc %}
 
-This guide shows the basics of how to update a Kubernetes resource in place using the patch manifest stage for the [Kubernetes Provider V2](/setup/install/providers/kubernetes-v2) provider.
+This guide shows the basics of how to update a Kubernetes resource in place using the patch manifest stage for the [Kubernetes provider](/setup/install/providers/kubernetes-v2) provider.
 
 There are a few steps:
 

--- a/guides/user/kubernetes-v2/rollout-strategies/index.md
+++ b/guides/user/kubernetes-v2/rollout-strategies/index.md
@@ -8,7 +8,7 @@ sidebar:
 {% include toc %}
 
 This guide describes how to take advantage of the
-[Kubernetes V2](/setup/install/providers/kubernetes-v2) provider's first-class support
+[Kubernetes](/setup/install/providers/kubernetes-v2) provider's first-class support
 for common rollout strategies, including dark, highlander, and red/black rollouts.
 
 > **Note:** The implementation of these rollout strategies currently leverages Spinnaker's existing

--- a/guides/user/kubernetes-v2/traffic-management/index.md
+++ b/guides/user/kubernetes-v2/traffic-management/index.md
@@ -8,7 +8,7 @@ sidebar:
 {% include toc %}
 
 This guide shows the basics of how to manage traffic during deployments using
-[Kubernetes Provider V2](/setup/install/providers/kubernetes-v2). This includes
+the [Kubernetes provider](/setup/install/providers/kubernetes-v2). This includes
 automatically attaching a
 [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
 to a workload during deployment, and defining pipelines to perform blue/green
@@ -155,8 +155,7 @@ application. When completed, an execution of this pipeline will look like:
 
 You need the following:
 
-1. Spinnaker with a [Kubernetes Provider
-   V2](/setup/install/providers/kubernetes-v2) configured
+1. Spinnaker with the [Kubernetes provider](/setup/install/providers/kubernetes-v2) configured
 
 2. One service called `my-service` running in the cluster and namespace your
    pipeline will deploy to. For the purpose of this example we will assume it

--- a/reference/artifacts-with-artifactsrewrite/in-kubernetes-v2/index.md
+++ b/reference/artifacts-with-artifactsrewrite/in-kubernetes-v2/index.md
@@ -1,13 +1,13 @@
 ---
 layout: single
-title:  "Artifacts In Kubernetes (Manifest Based)"
+title:  "Artifacts In Kubernetes"
 sidebar:
   nav: reference
 ---
 
 {% include toc %}
 
-Artifacts play an important role in the Kubernetes V2 provider. Everything from
+Artifacts play an important role in the Kubernetes provider. Everything from
 the manifests you deploy to the Docker images or ConfigMaps they reference
 can be expressed or deployed in terms of artifacts.
 

--- a/reference/artifacts/in-kubernetes-v2/index.md
+++ b/reference/artifacts/in-kubernetes-v2/index.md
@@ -1,13 +1,13 @@
 ---
 layout: single
-title:  "Artifacts In Kubernetes (Manifest Based)"
+title:  "Artifacts In Kubernetes"
 sidebar:
   nav: reference
 ---
 
 {% include toc %}
 
-Artifacts play an important role in the Kubernetes Provider V2. Everything from
+Artifacts play an important role in the Kubernetes provider. Everything from
 the manifests you deploy, to the Docker images or ConfigMaps they reference
 can be expressed or deployed in terms of artifacts.
 

--- a/reference/halyard/high-availability.md
+++ b/reference/halyard/high-availability.md
@@ -13,7 +13,7 @@ When sharded, the new logical services are given new names. This means that thes
 
 Currently, this feature is only for Clouddriver and Echo.
 
-__Important:__ Halyard only supports this functionality for a [distributed Spinnaker deployment](/setup/install/environment/#distributed-installation) configured with a [manifest-based Kubernetes provider](/setup/install/providers/kubernetes-v2/).
+__Important:__ Halyard only supports this functionality for a [distributed Spinnaker deployment](/setup/install/environment/#distributed-installation) configured with the [Kubernetes provider](/setup/install/providers/kubernetes-v2/).
 
 ## HA Clouddriver
 

--- a/reference/providers/index.md
+++ b/reference/providers/index.md
@@ -20,8 +20,7 @@ These are the Cloud Providers currently supported by Spinnaker:
 * [Azure](/reference/providers/azure/)
 * [Cloud Foundry](/reference/providers/cf)
 * [Google Compute Engine](/reference/providers/gce/)
-* [Kubernetes](/reference/providers/kubernetes/) (legacy)
-* [Kubernetes V2](/reference/providers/kubernetes-v2) (manifest based)
+* [Kubernetes](/reference/providers/kubernetes-v2)
 * [Oracle Cloud](/reference/providers/oracle/)
 
 *Note:* The OpenStack provider was supported for a period of time, but after several releases without support [this RFC](https://github.com/spinnaker/spinnaker/issues/4316) concluded with the removal of the provider from Spinnaker. If you are interested in adding this provider back in and supporting it we would be more than happy to help revert the removal.

--- a/reference/providers/kubernetes-v2/index.md
+++ b/reference/providers/kubernetes-v2/index.md
@@ -1,20 +1,20 @@
 ---
 Layout: single
-title:  "Kubernetes Provider V2 (Manifest Based)"
+title:  "Kubernetes Provider"
 sidebar:
   nav: reference
 ---
 
 {% include toc %}
 
-This article describes how the Kubernetes provider v2 works and how it differs
+This article describes how the Kubernetes provider works and how it differs
 from other providers in Spinnaker. If you're unfamiliar with Kubernetes
 terminology, see the [Kubernetes
 documentation](https://kubernetes.io/docs/home/).
 
 # The manifest-based approach
 
-The Kubernetes provider v2 combines the strengths of Kubernetes's [declarative
+The Kubernetes provider combines the strengths of Kubernetes's [declarative
 infrastructure
 management](https://kubernetes.io/docs/tutorials/object-management-kubectl/declarative-object-management-configuration/)
 with Spinnaker's workflow engine for imperative steps when you need them. You
@@ -22,9 +22,8 @@ can fully specify all your infrastructure in the native Kubernetes manifest
 format but still express, for example, a multi-region canary-driven rollout.
 
 This is a significant departure from how deployments are managed in Spinnaker
-using other providers (including the [Kubernetes provider
-v1](https://www.spinnaker.io/reference/providers/kubernetes/)). The rest of this
-doc explains the differences.
+using other providers (including the [legacy Kubernetes provider](https://www.spinnaker.io/reference/providers/kubernetes/)).
+The rest of this doc explains the differences.
 
 ## No restrictive naming policies
 
@@ -48,7 +47,7 @@ Other providers in Spinnaker track operations that modify cloud resources. For
 example, if you run a resize operation, Spinnaker monitors that operation until
 the specified resize target is met. But because Kubernetes only tries to satisfy
 the desired _state_, and offers a level-based API for this purpose, the
-Kubernetes provider v2 uses the concept of "manifest stability."
+Kubernetes provider uses the concept of "manifest stability."
 
 A deployed manifest is considered stable when the Kubernetes controller-manager
 no longer needs to modify it, and it’s deemed “ready.” This assessment is
@@ -222,7 +221,7 @@ Spinnaker applies the following labels as of release 1.9:
 
 Resource mapping between Spinnaker and Kubernetes constructs, as well as the
 introduction of new types of resources, is a lot more flexible in the
-Kubernetes provider V2 than for other providers, because of how many types of
+Kubernetes provider than for other providers, because of how many types of
 resources Kubernetes supports. Also the Kubernetes extension
 mechanisms&mdash;called [Custom Resource Definitions
 (CRDs)](https://kubernetes.io/docs/concepts/api-extension/custom-resources/)&mdash;make

--- a/reference/providers/kubernetes.md
+++ b/reference/providers/kubernetes.md
@@ -7,7 +7,7 @@ redirect_from: /reference/providers/kubernetes-v1/
 ---
 
 > ⚠️ Spinnaker's legacy Kubernetes provider (V1) is [scheduled for removal](https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md) in Spinnaker 1.21.
-> We recommend using the [manifest-based provider (V2)](/reference/providers/kubernetes-v2) instead. 
+> We recommend using the [standard provider (V2)](/reference/providers/kubernetes-v2) instead. 
 
 {% include toc %}
 

--- a/setup/configuration/index.md
+++ b/setup/configuration/index.md
@@ -202,7 +202,6 @@ kubernetes:
   enabled: true
   accounts:
     - name: default
-      providerVersion: V2
       kubeconfigFile: configserver:kubeconfig.yml
       dockerRegistries:
         - accountName: dockerhub

--- a/setup/install/environment.md
+++ b/setup/install/environment.md
@@ -53,7 +53,7 @@ which you will install Spinnaker.
    This must be on a Kubernetes cluster. It does not have to be the same
    provider as the one you're using to deploy your applications.
 
-   * [Kubernetes (Manifest Based)](/setup/install/providers/kubernetes-v2)
+   * [Kubernetes](/setup/install/providers/kubernetes-v2)
 
    We recommend at least 4 cores and 8GB of RAM available in the cluster where
    you will deploy Spinnaker.

--- a/setup/install/providers/aws/index.md
+++ b/setup/install/providers/aws/index.md
@@ -26,4 +26,4 @@ how they are configured in AWS.
 That being said, below are some ways to configure Amazon Web Services (AWS) Cloud Provider. You may choose one or more based on your preferences
 
 * [Amazon Elastic Container Service (ECS)](/setup/install/providers/aws/aws-ecs/) - Use this option, if you want to manage containers in [Amazon ECS](https://aws.amazon.com/ecs/)
-* [Amazon Elastic Kubernetes Service (EKS)](/setup/install/providers/kubernetes-v2/aws-eks/) - Use this option, if you want to manage containers in [Amazon EKS](https://aws.amazon.com/eks/). This option uses [Kubernetes V2 (manifest based) Clouddriver](/setup/install/providers/kubernetes-v2)
+* [Amazon Elastic Kubernetes Service (EKS)](/setup/install/providers/kubernetes-v2/aws-eks/) - Use this option, if you want to manage containers in [Amazon EKS](https://aws.amazon.com/eks/). This option uses [Spinnaker's Kubernetes provider](/setup/install/providers/kubernetes-v2)

--- a/setup/install/providers/index.md
+++ b/setup/install/providers/index.md
@@ -28,7 +28,7 @@ Add as many of the following providers as you need. When you're done, return to 
 * [Cloud Foundry](/setup/install/providers/cf/)
 * [DC/OS](/setup/install/providers/dcos/)
 * [Google Compute Engine](/setup/install/providers/gce/)
-* [Kubernetes V2 (manifest based)](/setup/install/providers/kubernetes-v2/)
+* [Kubernetes](/setup/install/providers/kubernetes-v2/)
 * [Oracle](/setup/install/providers/oracle/)
 
 See also [`hal config provider`](/reference/halyard/commands/#hal-config-provider)

--- a/setup/install/providers/kubernetes-v2/ack/index.md
+++ b/setup/install/providers/kubernetes-v2/ack/index.md
@@ -8,8 +8,8 @@ sidebar:
 {% include toc %}
 
 This page describes how to set up a Kubernetes cluster on
-[ACK](https://www.alibabacloud.com/product/kubernetes) to be used as a Spinnaker
-Kubernetes v2 provider.
+[ACK](https://www.alibabacloud.com/product/kubernetes) to be used with Spinnaker's
+Kubernetes provider.
 
 # Create a cluster
 

--- a/setup/install/providers/kubernetes-v2/aws-eks.md
+++ b/setup/install/providers/kubernetes-v2/aws-eks.md
@@ -1,6 +1,6 @@
 ---
 layout: single
-title:  "Set up a Kubernetes v2 provider for Amazon EKS"
+title:  "Set up the Kubernetes provider for Amazon EKS"
 sidebar:
   nav: setup
 redirect_from: 
@@ -167,7 +167,7 @@ kubectl config set-context $CONTEXT --user ${CONTEXT}-token-user
 Add `eks-spinnaker` cluster as a Kubernetes provider:
 
 ```
-hal config provider kubernetes account add eks-spinnaker --provider-version v2 --context $CONTEXT
+hal config provider kubernetes account add eks-spinnaker --context $CONTEXT
 ```
 
 ### 4. Enable artifact support

--- a/setup/install/providers/kubernetes-v2/gke/index.md
+++ b/setup/install/providers/kubernetes-v2/gke/index.md
@@ -8,8 +8,8 @@ sidebar:
 {% include toc %}
 
 This page describes how to set up a Kubernetes cluster on
-[GKE](https://cloud.google.com/kubernetes-engine/) to be used as a Spinnaker
-Kubernetes v2 provider. The process is very simple, but you need to do some
+[GKE](https://cloud.google.com/kubernetes-engine/) to be used with Spinnaker's
+Kubernetes provider. The process is very simple, but you need to do some
 specific things to allow Spinnaker to authenticate against your cluster.
 
 > Note: To manage and create clusters in a given project, you need the

--- a/setup/install/providers/kubernetes-v2/index.md
+++ b/setup/install/providers/kubernetes-v2/index.md
@@ -177,11 +177,12 @@ reasons:
   adopt the Kubernetes resources and operations more natively.
   
 * The V2 provider does __not__ use the [Docker Registry
-  Provider](https://www.spinnaker.io/setup/install/providers/docker-registry/), and we
-  encourage you to stop using the Docker Registry accounts in Spinnaker.  The
-  V2 provider requires that you manage your private registry [configuration and
-  authentication](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
-  yourself.
+  Provider](https://www.spinnaker.io/setup/install/providers/docker-registry/).
+  You may still need Docker Registry accounts to trigger pipelines, but
+  otherwise we encourage you to stop using Docker Registry accounts in Spinnaker.
+  The V2 provider requires that you manage your private registry [configuration
+  and authentication](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+  yourself.  
 
 However, you can easily migrate your _infrastructure_ into the V2 provider.
 For any V1 account you have running, you can add a V2 account following the

--- a/setup/install/providers/kubernetes-v2/index.md
+++ b/setup/install/providers/kubernetes-v2/index.md
@@ -1,6 +1,6 @@
 ---
 layout: single
-title:  "Kubernetes Provider V2 (Manifest Based)"
+title:  "Kubernetes Provider"
 sidebar:
   nav: setup
 ---
@@ -8,16 +8,14 @@ sidebar:
 
 {% include toc %}
 
-The Spinnaker Kubernetes V2 provider fully supports manifest-based deployments and is the recommended provider for deploying to Kubernetes with Spinnaker.
-[Kubernetes provider V1](https://www.spinnaker.io/setup/install/providers/kubernetes/){:target="\_blank"}
+Spinnaker's Kubernetes provider fully supports Kubernetes-native, manifest-based deployments and is the recommended provider for deploying to Kubernetes with Spinnaker.
+[Spinnaker's legacy Kubernetes provider](https://www.spinnaker.io/setup/install/providers/kubernetes/){:target="\_blank"}
 is [scheduled for removal](https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md){:target="\_blank"} in Spinnaker 1.21.
 
 ## Accounts
 
-For Kubernetes V2, a Spinnaker [Account](/concepts/providers/#accounts) maps to a
-credential that can authenticate against your Kubernetes Cluster. Unlike with
-the V1 provider, in V2 the Account does not require any Docker Registry
-Accounts.
+A Spinnaker [Account](/concepts/providers/#accounts) maps to a
+credential that can authenticate against your Kubernetes Cluster.
 
 ## Prerequisites
 
@@ -153,14 +151,11 @@ metadata:
 
 <span class="begin-collapsible-section"></span>
 
-## Migrating from the V1 provider
+## Migrating from Spinnaker's legacy Kubernetes provider
 
-> :warning: The V2 provider does __not__ use the [Docker Registry
-> Provider](https://www.spinnaker.io/setup/install/providers/docker-registry/), and we
-> encourage you to stop using the Docker Registry accounts in Spinnaker.  The
-> V2 provider requires that you manage your private registry [configuration and
-> authentication](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
-> yourself.
+> Prior to the deprecation of Spinnaker's legacy (V1) Kubernetes provider, the
+> standard provider was often referred to as the V2 provider. For clarity, this
+> section refers to the providers as the V1 and V2 providers.
 
 There is no automatic pipeline migration from the V1 provider to V2, for a few
 reasons:
@@ -180,6 +175,13 @@ reasons:
   Kubernetes. To avoid building dense and brittle mappings between Spinnaker's
   logical resources and Kubernetes's infrastructure resources, we chose to
   adopt the Kubernetes resources and operations more natively.
+  
+* The V2 provider does __not__ use the [Docker Registry
+  Provider](https://www.spinnaker.io/setup/install/providers/docker-registry/), and we
+  encourage you to stop using the Docker Registry accounts in Spinnaker.  The
+  V2 provider requires that you manage your private registry [configuration and
+  authentication](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+  yourself.
 
 However, you can easily migrate your _infrastructure_ into the V2 provider.
 For any V1 account you have running, you can add a V2 account following the
@@ -204,8 +206,7 @@ Then add the account:
 ```bash
 CONTEXT=$(kubectl config current-context)
 
-hal config provider kubernetes account add my-k8s-v2-account \
-    --provider-version v2 \
+hal config provider kubernetes account add my-k8s-account \
     --context $CONTEXT
 ```
 

--- a/setup/install/providers/kubernetes-v2/oke/index.md
+++ b/setup/install/providers/kubernetes-v2/oke/index.md
@@ -8,8 +8,8 @@ sidebar:
 {% include toc %}
 
 This page describes how to set up a Kubernetes cluster on
-[OKE](https://cloud.oracle.com/containers/kubernetes-engine/) to be used as a Spinnaker
-Kubernetes v2 provider. 
+[OKE](https://cloud.oracle.com/containers/kubernetes-engine/) to be used with Spinnaker's
+Kubernetes provider. 
 
 # Create a cluster
 
@@ -26,8 +26,7 @@ to download kubectl configuration file.
 Run the following `hal` command to add an account named `my-k8s-v2-acct` to your list of Kubernetes accounts:
 
 ```bash
-hal config provider kubernetes account add my-k8s-v2-acct \
-    --provider-version v2 \
+hal config provider kubernetes account add my-k8s-acct \
     --context $(kubectl config current-context)
 ```
 Enable the Kubernetes provider:

--- a/setup/install/providers/kubernetes.md
+++ b/setup/install/providers/kubernetes.md
@@ -9,7 +9,7 @@ redirect_from:
 ---
 
 > ⚠️ Spinnaker's legacy Kubernetes provider (V1) is [scheduled for removal](https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md) in Spinnaker 1.21.
-> We recommend using the [manifest-based provider (V2)](/setup/install/providers/kubernetes-v2) instead. 
+> We recommend using the [standard provider (V2)](/setup/install/providers/kubernetes-v2) instead. 
 
 {% include toc %}
 

--- a/setup/quickstart/faq.md
+++ b/setup/quickstart/faq.md
@@ -187,21 +187,17 @@ These settings will forward all external communication through the proxy server 
 keeping internal traffic non-proxied. Additional information can be found 
 [here.](https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html){:target="\_blank"}
 
-The Kubernetes V2 provider must be handled differently. Because the Kubernetes V2 provider 
-uses `kubectl` (which uses curl), you must set environment variablesif you want 
-Kubernetes V2 traffic to be proxied. 
+The Kubernetes provider must be handled differently. Because the Kubernetes provider 
+uses `kubectl` (which uses curl), you must set environment variables if you want 
+Kubernetes traffic to be proxied. 
 
-An example `clouddriver.yml` that will proxy Kubernetes V2 traffic will look like:
+An example `clouddriver.yml` that will proxy Kubernetes traffic will look like:
 ```yaml
 env:
   HTTP_PROXY: "proxyaddress:proxyport"
   HTTPS_PROXY: "proxyaddress:proxyport"
   NO_PROXY: "localhost,127.0.0.1,*.spinnaker" 
 ```
-
-If you are using both the V1 and V2 version of the Kubernetes provider, you'll need to supply both sets of 
-proxy definitions. 
-
 
 ## What is the best way to delete a Spinnaker deployment?
 

--- a/setup/quickstart/halyard-gke-deploy-rbac/index.md
+++ b/setup/quickstart/halyard-gke-deploy-rbac/index.md
@@ -147,7 +147,6 @@ At the end of this guide you will have:
 
    ```bash
    hal config provider kubernetes account add my-test-account \
-     --provider-version v2 \
      --context $(kubectl config current-context)
    ```
 


### PR DESCRIPTION
Related to: https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md

The Kubernetes SIG has agreed on standardized naming for Spinnaker's V1 and V2 Kubernetes providers:
- We will refer to the V2 provider as "the Kubernetes provider."
- We will refer to the V1 provider as "the legacy Kubernetes provider."

The primary goal of this standardization is to decrease friction for new users and evaluators, who should not need to understand which sets of terminology ("V2", "Manifest-based") refer to which provider, or even know that there was a legacy provider. A secondary goal is to improve perception of Spinnaker's Kubernetes provider as Kubernetes-native, which was arguably impeded by frequently referring to it as a "Manifest-based" provider, which sounds a bit dated given that applying YAML is the de facto way to deploy to Kubernetes.

