### PR TITLE
fix(docs): fix Travis and Wercker docs

### DIFF
--- a/setup/ci/travis.md
+++ b/setup/ci/travis.md
@@ -25,9 +25,12 @@ repos you should see.
 
    `hal config ci travis enable`
 
-1. If you're using Spinnaker 1.19 or earlier, turn on the Travis stage feature:
+1. If you're using Spinnaker 1.19 or earlier, enable the Travis stage by adding
+the following to your [Deck custom profile](/reference/halyard/custom/#custom-profile-for-deck):
 
-   `hal config features edit --travis true`
+    ```js
+     window.spinnakerSettings.feature.travis = true;
+    ```
 
 1. Add a Travis CI master named my-travis-master (or any arbitrary human-readable
 name):

--- a/setup/ci/wercker.md
+++ b/setup/ci/wercker.md
@@ -28,11 +28,12 @@ and credentials.
    hal config ci wercker enable
    ```
 
-2. If you're using Spinnaker 1.19 or earlier, make sure that the Wercker stage feature flag is turned on:
+2. If you're using Spinnaker 1.19 or earlier, enable the Wercker stage by adding
+the following to your [Deck custom profile](/reference/halyard/custom/#custom-profile-for-deck):
 
-   ```bash
-   hal config features edit --wercker true
-   ```
+    ```js
+     window.spinnakerSettings.feature.wercker = true;
+    ```
 
 3. Next, add a Wercker master i.e. a connection to Wercker from Spinnaker.
       ```bash


### PR DESCRIPTION
The prior docs would only work with a version of Halyard prior to 1.34. Given that we're going to stop supporting these stage-specific feature flags in 1.20 in favor of the `hiddenStages` setting, which will need to be manually added to Deck's custom profile (not exposed in Halyard), I'd prefer to just update the existing documentation to add the stage-specific flags to Deck's custom profile, as this will work regardless of Halyard version.