### PR TITLE
docs(plugins): Remove plugin deploy example; add text that only backend plugins work in 1.19.x

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -398,8 +398,8 @@ guides:
         children:
           - title: Users Guide
             url: /guides/user/plugins/user-guide/
-          - title: pf4jStagePlugin Deployment Example
-            url: /guides/user/plugins/deploy-example/
+          #- title: pf4jStagePlugin Deployment Example
+            #url: /guides/user/plugins/deploy-example/
       - title: Kubernetes (Manifest Based)
         collapsed: true
         children:

--- a/guides/developer/plugin-creators/overview.md
+++ b/guides/developer/plugin-creators/overview.md
@@ -8,6 +8,7 @@ redirect-from: /guides/developer/plugin-creators/
 
 {% include alpha version="1.19.4" %}
 
+>Note: Spinnaker 1.19.x only supports backend plugins due to a bug in Deck.
 
 {% include toc %}
 

--- a/guides/user/plugins/deploy-example.md
+++ b/guides/user/plugins/deploy-example.md
@@ -1,6 +1,7 @@
 ---
 layout: single
 title:  "pf4jStagePlugin Deployment Example"
+published: false
 sidebar:
   nav: guides
 ---

--- a/guides/user/plugins/user-guide.md
+++ b/guides/user/plugins/user-guide.md
@@ -9,6 +9,8 @@ redirect_from:
 
 {% include alpha version="1.19.4" %}
 
+>Note: Spinnaker 1.19.x only supports backend plugins due to a bug in Deck.
+
 {% include toc %}
 
 In this guide, you add an existing plugin from an [example repository](https://github.com/spinnaker-plugin-examples/examplePluginRepository) to Spinnaker. See the [Plugin Creators Guide](/guides/developer/plugin-creators/overview/) for how to create a plugin.


### PR DESCRIPTION
- add "published: false" to  "pf4jStagePlugin Deployment Example" (guides/user/plugins/deploy-example.md). Frontend plugins do not work in 1.19.x due to a bug in Deck. I didn't want to delete this file, because I plan to update and publish it again when frontend plugins do work in Spinnaker.
- add note to plugin creators overview and plugin users page noting that Spinnaker 1.19.4 only supports backend plugins