### PR TITLE
fix(docs): Fix repo build status images

### DIFF
--- a/community/contributing/build-statuses/index.md
+++ b/community/contributing/build-statuses/index.md
@@ -44,20 +44,20 @@ services:
 ## Core Services
 
 {% for svc in page.services.core %}
-  {% capture altTxt%}{{svc | captialize }} Build Status{% endcapture %}
-  {% capture githubStatusImg%}https://github.com/spinnaker/{{svc}}/workflows/{{svc | capitalize}}%20CI/badge.svg{% endcapture %}
+  {% capture altTxt%}{{svc | capitalize }} Build Status{% endcapture %}
+  {% capture githubStatusImg%}https://github.com/spinnaker/{{svc}}/workflows/Branch%20Build/badge.svg{% endcapture %}
   {% capture githubLink%}https://github.com/spinnaker/{{svc}}/actions?query=workflow%3A%22Branch+Build%22+branch%3Amaster{% endcapture%}
 
-  * [![{{altTxt}}]({{githubStatusImg}}){:style="height: 30px"}]({{githubLink}}){:target="\_blank"}
+  * {{svc | capitalize }} [![{{altTxt}}]({{githubStatusImg}}){:style="height: 25px"}]({{githubLink}}){:target="\_blank"}
 {% endfor %}
 
 
 ## Optional and Supporting Services
 
 {% for svc in page.services.supporting %}
-  {% capture altTxt%}{{svc | captialize }} Build Status{% endcapture %}
-  {% capture githubStatusImg%}https://github.com/spinnaker/{{svc}}/workflows/{{svc | capitalize}}%20CI/badge.svg{% endcapture %}
+  {% capture altTxt%}{{svc | capitalize }} Build Status{% endcapture %}
+  {% capture githubStatusImg%}https://github.com/spinnaker/{{svc}}/workflows/Branch%20Build/badge.svg{% endcapture %}
   {% capture githubLink%}https://github.com/spinnaker/{{svc}}/actions?query=workflow%3A%22Branch+Build%22+branch%3Amaster{% endcapture%}
 
-  * [![{{altTxt}}]({{githubStatusImg}}){:style="height: 30px"}]({{githubLink}}){:target="\_blank"}
+  * {{svc | capitalize }} [![{{altTxt}}]({{githubStatusImg}}){:style="height: 25px"}]({{githubLink}}){:target="\_blank"}
 {% endfor %}


### PR DESCRIPTION
Since the GHActions were renamed, these status are working against old workflow names that no longer exist, yet they remain green since the last build before they were removed was (I assume) green.

Now that the repo name is not longer in the GHA name, though, I must prepend the repo name, which makes the page slightly uglier IMO. We also have to fix Deck to comply with the new naming scheme.

![Q5vaooZrd53](https://user-images.githubusercontent.com/13141550/80622752-3c5f9780-8a17-11ea-8145-4398ca3945de.png)
