### PR TITLE
feat(builds): List releaseN..N-2 statuses, too

### DIFF
--- a/community/contributing/build-statuses/index.md
+++ b/community/contributing/build-statuses/index.md
@@ -12,20 +12,26 @@ services:
   - fiat
   - front50
   - gate
-  - halyard
   - igor
   - kayenta
   - kork
   - orca
   - rosco
+  - spinnaker-monitoring
   supporting:
+  - halyard
   - keel
   - keiko
   - spin
   - spinnaker.github.io
   - spinnaker-gradle-project
-  - spinnaker-monitoring
   - swabbie
+
+branches:
+- master
+- release-1.20.x
+- release-1.19.x
+- release-1.18.x
 ---
 
 [Build Cop Rotation History](https://github.com/spinnaker/spinnaker/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Abuild-cop-rotation)
@@ -36,28 +42,42 @@ services:
 
 > You must be a member of the `build-cops` GitHub Team to access nightly and release integration tests.
 
-* [![Master Build Status](https://builds.spinnaker.io/buildStatus/icon?job=Flow_BuildAndValidate&subject=All%20at%20HEAD){:style="height: 30px"}](https://builds.spinnaker.io/job/Flow_BuildAndValidate/){:target="\_blank"}
-* [![1.19.x Build Status](https://builds.spinnaker.io/buildStatus/icon?job=Flow_BuildAndValidate_1_19_x&subject=Release%201.19.x){:style="height: 30px"}](https://builds.spinnaker.io/job/Flow_BuildAndValidate_1_19_x/){:target="\_blank"}
-* [![1.18.x Build Status](https://builds.spinnaker.io/buildStatus/icon?job=Flow_BuildAndValidate_1_18_x&subject=Release%201.18.x){:style="height: 30px"}](https://builds.spinnaker.io/job/Flow_BuildAndValidate_1_18_x/){:target="\_blank"}
-* [![1.17.x Build Status](https://builds.spinnaker.io/buildStatus/icon?job=Flow_BuildAndValidate_1.17.x&subject=Release%201.17.x){:style="height: 30px"}](https://builds.spinnaker.io/job/Flow_BuildAndValidate_1.17.x/){:target="\_blank"}
+{% for branch in page.branches %}
+  {%- capture subject -%}{{branch | capitalize}}{%- endcapture -%}
+  {%- if branch == "master" -%}
+    {%- capture job -%}Flow_BuildAndValidate{%- endcapture -%}
+  {%- else -%}
+    {%- capture job -%}Flow_BuildAndValidate_{{branch | remove: "release-" | replace: ".", "_"}}{%- endcapture -%}
+  {%- endif -%}
+* [![{{branch}} Build Status](https://builds.spinnaker.io/buildStatus/icon?job={{job}}&subject={{subject}}){:style="height: 25px"}](https://builds.spinnaker.io/job/{{job}}/){:target="\_blank"}
+{% endfor %}
+
 
 ## Core Services
 
+Service | Branch | Status
+------- | ------ | ------
 {% for svc in page.services.core %}
-  {% capture altTxt%}{{svc | capitalize }} Build Status{% endcapture %}
-  {% capture githubStatusImg%}https://github.com/spinnaker/{{svc}}/workflows/Branch%20Build/badge.svg{% endcapture %}
-  {% capture githubLink%}https://github.com/spinnaker/{{svc}}/actions?query=workflow%3A%22Branch+Build%22+branch%3Amaster{% endcapture%}
+  {%- for branch in page.branches -%}
+    {%- if branch == "master" -%}
+      {%- capture svcCol -%}**{{ svc | capitalize }}**{%- endcapture -%}
+    {%- else -%}
+      {%- capture svcCol -%}{%- endcapture -%}
+    {%- endif -%}
+    {%- capture altTxt -%}{{ svc | capitalize }} Build Status{%- endcapture -%}
+    {%- capture githubStatusImg -%}https://github.com/spinnaker/{{svc}}/workflows/Branch%20Build/badge.svg?branch={{branch}}{%- endcapture -%}
+    {%- capture githubLink -%}https://github.com/spinnaker/{{svc}}/actions?query=workflow%3A%22Branch+Build%22+branch%3A{{branch}}{%- endcapture -%}
 
-  * {{svc | capitalize }} [![{{altTxt}}]({{githubStatusImg}}){:style="height: 25px"}]({{githubLink}}){:target="\_blank"}
-{% endfor %}
+    {{svcCol}} | `{{branch}}` | [![{{altTxt}}]({{githubStatusImg}}){:style="height: 25px"}]({{githubLink}}){:target="\_blank"}
+{% endfor %}{% endfor %}
 
 
 ## Optional and Supporting Services
 
 {% for svc in page.services.supporting %}
-  {% capture altTxt%}{{svc | capitalize }} Build Status{% endcapture %}
-  {% capture githubStatusImg%}https://github.com/spinnaker/{{svc}}/workflows/Branch%20Build/badge.svg{% endcapture %}
-  {% capture githubLink%}https://github.com/spinnaker/{{svc}}/actions?query=workflow%3A%22Branch+Build%22+branch%3Amaster{% endcapture%}
+  {% capture altTxt %}{{ svc | capitalize }} Build Status{% endcapture %}
+  {% capture githubStatusImg %}https://github.com/spinnaker/{{svc}}/workflows/Branch%20Build/badge.svg{% endcapture %}
+  {% capture githubLink %}https://github.com/spinnaker/{{svc}}/actions?query=workflow%3A%22Branch+Build%22+branch%3Amaster{% endcapture %}
 
   * {{svc | capitalize }} [![{{altTxt}}]({{githubStatusImg}}){:style="height: 25px"}]({{githubLink}}){:target="\_blank"}
 {% endfor %}


### PR DESCRIPTION
Pulls the branch names into metadata and transforms them as needed. 

The extra dashes in the liquid template `{%- -%}` suppress whitespace, which Markdown tables are sensitive to.

Replaces https://github.com/spinnaker/spinnaker.github.io/pull/1822

Preview:

![WuY5gq3aw8e](https://user-images.githubusercontent.com/13141550/80638771-f57d9c00-8a2e-11ea-951f-8d5c0fd83c64.png)
