### PR TITLE
docs(aws): Expanded description on the aws iam concepts #1804

### DIFF
--- a/setup/install/providers/aws/index.md
+++ b/setup/install/providers/aws/index.md
@@ -9,33 +9,33 @@ sidebar:
 
 ### Concepts
 
-There are two types of Accounts in the Spinnaker AWS provider: __AWS Managing__ account and __AWS Managed__ account(s)
+There are two types of Accounts in the Spinnaker AWS provider: __AWS Managing__ account and __AWS Managed__ account(s).
 
-From the Spinnaker perspective, [Halyard](https://www.spinnaker.io/reference/halyard/) configures Spinnaker to use the __AWS Managing__ account and take control of the __AWS Managed__ account(s).
+From the Spinnaker perspective, [Halyard](https://www.spinnaker.io/reference/halyard/) configures Spinnaker to use the __AWS Managing__ account to control the __AWS Managed__ account(s).
 
 **_Note_** The AWS IAM structure must be set up prior to adding the Spinnaker AWS Provider with Halyard.
 
 
-From the AWS perspective, __AWS Managing__ account will assume control of the __AWS Managed__ account(s) through the use of AWS IAM Roles. By assuming a role across AWS Accounts is how Spinnaker can control AWS resources from multiple __AWS Managed__ accounts.
+From the AWS perspective, __AWS Managing__ account assumes control of the __AWS Managed__ account(s) through the use of AWS IAM Roles. By assuming a role across AWS Accounts, Spinnaker can control AWS resources from multiple __AWS Managed__ accounts.
 
 Refer to [AWS IAM Providing Access to multiple AWS Accounts](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_aws-accounts.html) for AWS technical details.
 
 
-1. __AWS Managing__ account. There is always exactly one managing account. his
-   account is what Spinnaker authenticates as, and if necessary, uses to assumes roles
+1. __AWS Managing__ account. There is always exactly one managing account. This
+   account is what Spinnaker authenticates as and, if necessary, uses to assumes roles
    in the managed account(s).
 2. __AWS Managed__. Every AWS account that you want to modify resources in is a
-   managed account. Managed accounts require AWS IAM policies and a trust relationship to grant AssumeRole access to the
+   managed account. Managed accounts require AWS IAM policies and a trust relationship to grant `AssumeRole` access to the
    managed account(s). 
    
-   The __AWS Managing__ account assumes the __AWS Managed__ account(s)
+   The __AWS Managing__ account assumes the roles of the __AWS Managed__ account(s).
    
-   __Use Case Example:__ AWS __Managing__ account __*spinnakermanaging*__ can assume the __Managed__ role in the accounts __*accountdev*__, __*accountstaging*__, __*accountprod*__ and deploy a baked AMI in the pipeline.
+   __Example:__ AWS __Managing__ account `spinnakermanaging` can assume the __Managed__ role in the accounts __*accountdev*__, __*accountstaging*__, __*accountprod*__ and deploy a baked AMI in the pipeline.
 
-![](concepts.png)
+![Example diagram of managing and managed roles](concepts.png)
 
 
-That being said, below are some ways to configure Amazon Web Services (AWS) Cloud Provider. You may choose one or more based on your preferences
+There are several ways to configure the Amazon Web Services (AWS) Cloud Provider. Choose one or more based on your requirements:
 
 * [Amazon Elastic Compute Cloud (EC2)](/setup/install/providers/aws/aws-ec2/) - - Use this option, if you want to manage [EC2 Instances](https://aws.amazon.com/ec2/) via Spinnaker
 * [Amazon Elastic Container Service (ECS)](/setup/install/providers/aws/aws-ecs/) - Use this option, if you want to manage containers in [Amazon ECS](https://aws.amazon.com/ecs/)

--- a/setup/install/providers/aws/index.md
+++ b/setup/install/providers/aws/index.md
@@ -9,16 +9,28 @@ sidebar:
 
 ### Concepts
 
-There are two types of Accounts in the Spinnaker AWS provider; however, the
-distinction is not made in how they are configured using Halyard, but instead
-how they are configured in AWS.
+There are two types of Accounts in the Spinnaker AWS provider: __AWS Managing__ account and __AWS Managed__ account(s)
 
-1. Managing accounts. There is always exactly one managing account, this
-   account is what Spinnaker authenticates as, and if necessary, assumes roles
-   in the managed accounts.
-2. Managed accounts. Every account that you want to modify resources in is a
-   managed account. These will be configured to grant AssumeRole access to the
-   managed account. __This includes the managing account!__
+From the Spinnaker perspective, [Halyard](https://www.spinnaker.io/reference/halyard/) configures Spinnaker to use the __AWS Managing__ account and take control of the __AWS Managed__ account(s).
+
+**_Note_** The AWS IAM structure must be set up prior to adding the Spinnaker AWS Provider with Halyard.
+
+
+From the AWS perspective, __AWS Managing__ account will assume control of the __AWS Managed__ account(s) through the use of AWS IAM Roles. By assuming a role across AWS Accounts is how Spinnaker can control AWS resources from multiple __AWS Managed__ accounts.
+
+Refer to [AWS IAM Providing Access to multiple AWS Accounts](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_aws-accounts.html) for AWS technical details.
+
+
+1. __AWS Managing__ account. There is always exactly one managing account. his
+   account is what Spinnaker authenticates as, and if necessary, uses to assumes roles
+   in the managed account(s).
+2. __AWS Managed__. Every AWS account that you want to modify resources in is a
+   managed account. Managed accounts require AWS IAM policies and a trust relationship to grant AssumeRole access to the
+   managed account(s). 
+   
+   The __AWS Managing__ account assumes the __AWS Managed__ account(s)
+   
+   __Use Case Example:__ AWS __Managing__ account __*spinnakermanaging*__ can assume the __Managed__ role in the accounts __*accountdev*__, __*accountstaging*__, __*accountprod*__ and deploy a baked AMI in the pipeline.
 
 ![](concepts.png)
 
@@ -27,4 +39,4 @@ That being said, below are some ways to configure Amazon Web Services (AWS) Clou
 
 * [Amazon Elastic Compute Cloud (EC2)](/setup/install/providers/aws/aws-ec2/) - - Use this option, if you want to manage [EC2 Instances](https://aws.amazon.com/ec2/) via Spinnaker
 * [Amazon Elastic Container Service (ECS)](/setup/install/providers/aws/aws-ecs/) - Use this option, if you want to manage containers in [Amazon ECS](https://aws.amazon.com/ecs/)
-* [Amazon Elastic Kubernetes Service (EKS)](/setup/install/providers/kubernetes-v2/aws-eks/) - Use this option, if you want to manage containers in [Amazon EKS](https://aws.amazon.com/eks/). This option uses [Spinnaker's Kubernetes provider](/setup/install/providers/kubernetes-v2)
+* [Amazon Elastic Kubernetes Service (EKS)](/setup/install/providers/kubernetes-v2/aws-eks/) - Use this option, if you want to manage containers in [Amazon EKS](https://aws.amazon.com/eks/). This option uses [Kubernetes V2 (manifest based) Clouddriver](/setup/install/providers/kubernetes-v2)


### PR DESCRIPTION
Branch was removed in this PR https://github.com/spinnaker/spinnaker.github.io/pull/1804
This PR contains the changes suggested by @brian-armory 
I am so sorry if it was me.
Describes how Halyard interacts with AWS IAM
Explains the 2 aws accounts for aws provider
Reminds user that AWS IAM structure must be set prior to deploy spinnaker
Adds reference to AWS IAM doc