### PR TITLE
feat(docs): add curated changelog page & update release runbook

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -714,6 +714,8 @@ community:
         url: /community/releases/support-policy/
       - title: Release Manager Runbook
         url: /community/releases/release-manager-runbook
+      - title: Next Release Preview
+        url: /community/releases/next-release-preview
   - title: Contributing
     collapsed: true
     children:

--- a/community/releases/next-release-preview/index.md
+++ b/community/releases/next-release-preview/index.md
@@ -1,0 +1,20 @@
+---
+layout: single
+title:  "Next Release Preview"
+sidebar:
+  nav: community
+---
+
+{% include toc %}
+
+Please make a pull request to describe any changes you wish to highlight
+in the next release of Spinnaker. These notes will be prepended to the release
+changelog.
+
+## Coming Soon in Release 1.21
+
+### End of Support for the legacy Kubernetes Provider
+
+1.20 was the final release to include support for Spinnaker's legacy Kubernetes
+(V1) provider. Please migrate all Kubernetes accounts to the standard (V2)
+provider before upgrading to Spinnaker 1.21.

--- a/community/releases/release-manager-runbook/index.md
+++ b/community/releases/release-manager-runbook/index.md
@@ -94,7 +94,10 @@ job:
     
 1. Add the new Flow_BuildAndValidate_${RELEASE} job to the public
 [Build Statuses page](https://www.spinnaker.io/community/contributing/build-statuses/#nightly-and-release-integration-tests).
-Ping [#dev](https://spinnakerteam.slack.com/messages/dev/) with some version of
+Remove the oldest job. For each service under Core Services, add a row for the
+newest release branch, and remove the row for the oldest release branch.
+
+1. Ping [#dev](https://spinnakerteam.slack.com/messages/dev/) with some version of
 this message, including a link to the correct section of the changelog gist:
 
     > The release window for Spinnaker $VERSION is now open!  This means that

--- a/community/releases/release-manager-runbook/index.md
+++ b/community/releases/release-manager-runbook/index.md
@@ -104,13 +104,11 @@ this message, including a link to the correct section of the changelog gist:
     > release branches have been cut from master and those branches are only
     > accepting fixes for existing features.  Please contact $YOUR_NAME
     > (slack: $YOUR_SLACK_ID, github: $YOUR_GITHUB_ID, or email: $YOUR_EMAIL) if you
-    > would like a fix cherry-picked into the release or you would like to highlight
-    > a specific fix or feature in the release’s changelog. If you’d like to jog
-    > your memory of everything to be released with Spinnaker $VERSION, see the raw
-    > changelog here: $LINK_TO_CHANGELOG.
-
-1. Share a curated changelog with any partners from the community who want to
-add notes.
+    > would like a fix cherry-picked into the release. If you would like to highlight
+    > a specific fix or feature in the release’s changelog, please make a pull
+    > request against the [curated changelog](/community/releases/next-release-preview)
+    > by Friday. If you’d like to jog your memory of everything to be released
+    > with Spinnaker $VERSION, see the raw changelog here: $LINK_TO_CHANGELOG.
 
 1. When the Flow_BuildAndValidate_${RELEASE} job passes, ping
 [#dev](https://spinnakerteam.slack.com/messages/dev/) with a message that
@@ -142,8 +140,12 @@ release candidate is now validated and can be tested by running:
     1. Copy the changes for this release from the raw build changelog to the new
     1.nn.0.md file.
 
-    1. Add the notes from the curated changelog to the top of the gist,
-    formatting them for Markdown ([sample 1.nn.0 release notes](https://gist.github.com/spinnaker-release/cc4410d674679c5765246a40f28e3cad)).
+    1. Add the notes from the [curated changelog](/community/releases/next-release-preview)
+    to the top of the gist ([sample 1.nn.0 release notes](https://gist.github.com/spinnaker-release/cc4410d674679c5765246a40f28e3cad)).
+    
+    1. Reset the [curated changelog](/community/releases/next-release-preview)
+    for the next release by removing all added notes and incrementing the version
+    number in the heading.
 
 1. Run Publish_SpinnakerRelease:
 


### PR DESCRIPTION
* feat(docs): update release runbook 

  Updates the Release Runbook to reflect changes to the Build Statuses page.

* feat(docs): add curated changelog page 

  Let's improve the transparency of the release process by making the curated changelog notes public. Also updates release runbook instructions to account for new workflow.
