### PR TITLE
feat: Add API configs section

### DIFF
--- a/_data/configs/kork-web.json
+++ b/_data/configs/kork-web.json
@@ -1,0 +1,90 @@
+{
+  "groups": [
+    {
+      "name": "default",
+      "type": "com.netflix.spinnaker.config.TomcatConfigurationProperties",
+      "sourceType": "com.netflix.spinnaker.config.TomcatConfigurationProperties"
+    },
+    {
+      "name": "endpoints.resolved-env",
+      "type": "com.netflix.spinnaker.config.ResolvedEnvironmentConfigurationProperties",
+      "sourceType": "com.netflix.spinnaker.config.ResolvedEnvironmentConfigurationProperties"
+    },
+    {
+      "name": "management.endpoint.resolved-env",
+      "type": "com.netflix.spinnaker.endpoint.ResolvedEnvironmentEndpoint",
+      "sourceType": "com.netflix.spinnaker.endpoint.ResolvedEnvironmentEndpoint"
+    },
+    {
+      "name": "ok-http-client.interceptor",
+      "type": "com.netflix.spinnaker.config.OkHttpMetricsInterceptorProperties",
+      "sourceType": "com.netflix.spinnaker.config.OkHttpMetricsInterceptorProperties"
+    },
+    {
+      "name": "retrofit",
+      "type": "com.netflix.spinnaker.retrofit.RetrofitConfigurationProperties",
+      "sourceType": "com.netflix.spinnaker.retrofit.RetrofitConfigurationProperties"
+    },
+    {
+      "name": "server.ssl",
+      "type": "com.netflix.spinnaker.tomcat.x509.SslExtensionConfigurationProperties",
+      "sourceType": "com.netflix.spinnaker.tomcat.x509.SslExtensionConfigurationProperties"
+    }
+  ],
+  "properties": [
+    {
+      "name": "default.api-port",
+      "type": "java.lang.Integer",
+      "sourceType": "com.netflix.spinnaker.config.TomcatConfigurationProperties",
+      "defaultValue": -1
+    },
+    {
+      "name": "default.legacy-server-port",
+      "type": "java.lang.Integer",
+      "sourceType": "com.netflix.spinnaker.config.TomcatConfigurationProperties",
+      "defaultValue": -1
+    },
+    {
+      "name": "default.relaxed-path-characters",
+      "type": "java.lang.String",
+      "sourceType": "com.netflix.spinnaker.config.TomcatConfigurationProperties",
+      "defaultValue": ""
+    },
+    {
+      "name": "default.relaxed-query-characters",
+      "type": "java.lang.String",
+      "sourceType": "com.netflix.spinnaker.config.TomcatConfigurationProperties",
+      "defaultValue": ""
+    },
+    {
+      "name": "endpoints.resolved-env.keys-to-sanitize",
+      "type": "java.util.List<java.lang.String>",
+      "sourceType": "com.netflix.spinnaker.config.ResolvedEnvironmentConfigurationProperties"
+    },
+    {
+      "name": "management.endpoint.resolved-env.cache.time-to-live",
+      "type": "java.time.Duration",
+      "description": "Maximum time that a response can be cached.",
+      "sourceType": "com.netflix.spinnaker.endpoint.ResolvedEnvironmentEndpoint",
+      "defaultValue": "0ms"
+    },
+    {
+      "name": "management.endpoint.resolved-env.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable the resolvedEnv endpoint.",
+      "sourceType": "com.netflix.spinnaker.endpoint.ResolvedEnvironmentEndpoint",
+      "defaultValue": true
+    },
+    {
+      "name": "retrofit.log-level",
+      "type": "retrofit.RestAdapter$LogLevel",
+      "sourceType": "com.netflix.spinnaker.retrofit.RetrofitConfigurationProperties"
+    },
+    {
+      "name": "server.ssl.crl-file",
+      "type": "java.lang.String",
+      "sourceType": "com.netflix.spinnaker.tomcat.x509.SslExtensionConfigurationProperties"
+    }
+  ],
+  "hints": []
+}

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -540,6 +540,8 @@ reference:
     children:
     - title: Docs
       url: /reference/api/docs.html
+    - title: Configs
+      url: /reference/api/configs/
     - title: Swagger UI
       url: /reference/api/swagger-ui/
   - title: Cloud Providers

--- a/reference/api/configs.html
+++ b/reference/api/configs.html
@@ -1,0 +1,58 @@
+---
+layout: single
+title:  "Config files reference"
+sidebar:
+  nav: reference
+---
+
+<p>
+Spinnaker services are configured with yaml files.
+Usually they are generated and managed by halyard.
+<br>
+Halyard covers a subset of the available options. This reference contains a broader list.
+<br>
+This reference is generated collecting the outputs from the following json files in the build:
+<code>
+spring-configuration-metadata.json — [SERVICE-NAME]/build/classes/groovy/main/META-INF/spring-configuration-metadata.json
+</code>
+There might be other options not covered here.
+</p>
+
+
+{% for service in site.data.configs %}
+{% assign svc_name = service[0] %}
+<h2>{{ svc_name }}</h2>
+  <h3> Groups </h3>
+  <ul>
+    {% for svc in service[1].groups %}
+      <li>
+        Name: {{ svc.name }} <br>
+        Type: {{ svc.type}} <br>
+        SourceType: {{ svc.sourceType}}
+      </li>
+    {% endfor %}
+  </ul>
+  <h3> Properties </h3>
+  <ul>
+    {% for svc in service[1].properties %}
+      <li>
+        Name: {{ svc.name }} <br>
+        Type: {{ svc.type}} <br>
+        SourceType: {{ svc.sourceType}} <br>
+        Default: {{ svc.defaultValue }}
+      </li>
+    {% endfor %}
+
+</ul>
+
+<h3> Hints </h3>
+
+<ul>
+    {% for svc in service[1].hints %}
+      <li>
+        {{ svc }}
+      </li>
+    {% endfor %}
+  </ul>
+{% endfor %}
+

--- a/reference/api/index.md
+++ b/reference/api/index.md
@@ -6,4 +6,5 @@ sidebar:
 ---
 
 - [API documentation](/reference/api/docs.html)
+- [Config files](/reference/api/configs)
 - [Swagger UI Guide](/reference/api/swagger-ui) 


### PR DESCRIPTION
Spinnaker services are configured by yaml files, one each, and usually those files are generated by halyard.
A reference to halyard available configs [exists](https://www.spinnaker.io/reference/halyard/commands/) but it is very hard to match what is generated by it, just looking at the config files themselves.
Finally, halyard doesn't cover every possible available config nor it is really simple to know how to edit each service config manually.

In the context of configuration as code, handling such config files without halyard would be of great help, but in order to do so, better documentation must be put in place.

This PR is a prof of concept of how such documentation can be published, using [kork](https://github.com/spinnaker/kork) as example.
The idea is to fill a folder with the json files generated from the javadocs at build time and display those file in a new section under `/reference/api`.

Given that some services might lack extensive documentation at the moment, this PR should be a good incentive for everybody to increase the amount and quality of comments and documentation. I speak for myself but I would be way more encouraged to write javadocs if they will be accessible to a broad community.

This PR lacks 3 big things:

1. A change in the build process to publish those json files. I envision that the build process could create a PR on this repo with the new set of json and the website can be updated right after. This process should ensure testing and vetting of the new content, either manually or by a bot.
2. The length of this new /reference/api/config section will be huge and we might need to find ways to fraction it. I see 3 options: (i) separate interface like swagger; (ii) huge page with TOC per service like halyard; (iii) each service in a subpage, with a TOC in the index. I personally prefer option (iii)
3. It is unclear to me how many services will be covered from the beginning by this and how standard the generated json file is.