### PR TITLE
feat(oauth2): Improve OAuth 2.0 Documentation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -155,17 +155,21 @@ setup:
                  url: /setup/security/authentication/
                - title: SAML
                  url: /setup/security/authentication/saml/
-               - title: Oauth
+               - title: OAuth 2.0
                  collapsed: true
                  children:
                    - title: Overview
                      url: /setup/security/authentication/oauth/
-                   - title: Google
-                     url: /setup/security/authentication/oauth/google/
-                   - title: GitHub
-                     url: /setup/security/authentication/oauth/github/
+                   - title: Configuration
+                     url: /setup/security/authentication/oauth/config/
                    - title: Azure
                      url: /setup/security/authentication/oauth/azure/
+                   - title: GitHub
+                     url: /setup/security/authentication/oauth/github/
+                   - title: Google
+                     url: /setup/security/authentication/oauth/google/
+                   - title: Oracle Cloud
+                     url: /setup/security/authentication/oauth/oracle/
                - title: LDAP/Active Directory
                  url: /setup/security/authentication/ldap/
                - title: x509

--- a/setup/security/authentication/oauth/azure/index.md
+++ b/setup/security/authentication/oauth/azure/index.md
@@ -4,7 +4,9 @@ sidebar:
   nav: setup
 ---
 
-This page instructs you on how to obtain an OAuth 2.0 client ID and client secret for use with your Microsoft Azure tenant.
+This page instructs you on how to obtain an OAuth 2.0 client ID and client secret for
+use with your Microsoft Azure tenant. More extensive documentation is available on
+[Microsoft's site](https://docs.microsoft.com/en-us/azure/active-directory/azuread-dev/v1-protocols-oauth-code).
 
 ## Setting up an Azure Application Registration
 
@@ -19,13 +21,50 @@ This page instructs you on how to obtain an OAuth 2.0 client ID and client secre
 5. Click "Settings" -> "Keys". Under "Passwords", add a Key Description (eg Spinnaker), set the expiry and then click "Save".
    "Value" will now be populated. This is your client-secret, copy it to a safe place.
 
-## Applying the settings in hal
+## Configure Halyard
 
-Set up oauth2 with azure:
+You may configure Halyard either with the CLI or by manually editing the hal config.
 
-`hal config security authn oauth2 edit --provider azure --client-id (client id from above)  --client-secret (client secret from above)`
+### Hal config
 
-The Tenant ID of your organization is required for Azure OAuth2.0 login. To obtain it:
+```yaml
+security:
+  authn:
+    oauth2:
+      enabled: true
+      client:
+        clientId: # client ID from above
+        clientSecret: client-secret # client secret from above
+        accessTokenUri: https://login.microsoftonline.com/${azureTenantId}/oauth2/token
+        userAuthorizationUri: https://login.microsoftonline.com/${azureTenantId}/oauth2/authorize?resource=https://graph.windows.net
+        clientAuthenticationScheme: query
+        scope: profile
+      # You may want to restrict access to your Spinnaker by adding
+      # userInfoRequirements to further restrict access beyond beyond simply
+      # requiring that users have a valid account in your Azure AD Tenant.
+      userInfoRequirements: {}
+      resource:
+        userInfoUri: https://graph.windows.net/me?api-version=1.6
+      userInfoMapping:
+        email: userPrincipalName
+        firstName: givenName
+        lastName: surname
+      provider: AZURE
+```
+
+### CLI
+
+Set up OAuth 2.0 with azure:
+
+`hal config security authn oauth2 edit --provider azure --client-id (client ID from above)  --client-secret (client secret from above)`
+
+Now enable OAuth 2.0 using hal:
+
+`hal config security authn oauth2 enable`
+
+
+## Set environment variable
+The Tenant ID of your organization is required for Azure OAuth 2.0 login. To obtain it:
 1. Navigate to [https://portal.azure.com](https://portal.azure.com) and log in with your Azure credentials.
 2. On the left hand navigation pane, click "Azure Active Directory" --> "Properties".
 3. "Directory ID" is your Tenant ID.
@@ -35,7 +74,3 @@ In order to pass the Tenant ID to gate, we need to insert is as an environment v
 env:
   azureTenantId: (your tenant id)
 ```
-
-Now enable OAuth2 using hal:
-
-`hal config security authn oauth2 enable`

--- a/setup/security/authentication/oauth/azure/index.md
+++ b/setup/security/authentication/oauth/azure/index.md
@@ -17,9 +17,9 @@ use with your Microsoft Azure tenant. More extensive documentation is available 
    - Application type: Web app / API
    - Sign-on URL: https://localhost:8084/login (replace localhost with your Gate address if known, and `https` with `http` if appropriate)
    - Click "Create"
-4. Note the "Application ID", this is the client-id to pass to hal. Copy it to a safe place.
+4. Note the "Application ID", this is the client ID to pass to hal. Copy it to a safe place.
 5. Click "Settings" -> "Keys". Under "Passwords", add a Key Description (eg Spinnaker), set the expiry and then click "Save".
-   "Value" will now be populated. This is your client-secret, copy it to a safe place.
+   "Value" will now be populated. This is your client secret; copy it to a safe place.
 
 ## Configure Halyard
 
@@ -34,7 +34,7 @@ security:
       enabled: true
       client:
         clientId: # client ID from above
-        clientSecret: client-secret # client secret from above
+        clientSecret: # client secret from above
         accessTokenUri: https://login.microsoftonline.com/${azureTenantId}/oauth2/token
         userAuthorizationUri: https://login.microsoftonline.com/${azureTenantId}/oauth2/authorize?resource=https://graph.windows.net
         clientAuthenticationScheme: query

--- a/setup/security/authentication/oauth/config.md
+++ b/setup/security/authentication/oauth/config.md
@@ -20,10 +20,10 @@ security:
         # The OAuth client secret you have configured with your OAuth provider.
         clientSecret: string 
           
-        # The access token uri for your OAuth provider.
+        # The access token URI for your OAuth provider.
         accessTokenUri: string
           
-        # The user authorization uri for your OAuth 2.0 provider.
+        # The user authorization URI for your OAuth 2.0 provider.
         userAuthorizationUri: string
           
         # The scope to request when obtaining an access token from your

--- a/setup/security/authentication/oauth/config.md
+++ b/setup/security/authentication/oauth/config.md
@@ -1,0 +1,67 @@
+---
+title:  "OAuth 2.0 Configuration"
+sidebar:
+  nav: setup
+---
+
+## Halyard config
+
+The full schema for configuring OAuth 2.0 via Halyard is:
+```yaml
+security:
+  authn:
+    oauth2:
+      # Whether OAuth 2.0 is enabled.
+      enabled: boolean
+      client:
+        # The OAuth client ID you have configured with your OAuth 2.0 provider.
+        clientId: string
+        
+        # The OAuth client secret you have configured with your OAuth provider.
+        clientSecret: string 
+          
+        # The access token uri for your OAuth provider.
+        accessTokenUri: string
+          
+        # The user authorization uri for your OAuth 2.0 provider.
+        userAuthorizationUri: string
+          
+        # The scope to request when obtaining an access token from your
+        # OAuth 2.0 provider.
+        scope: string
+
+        # The externally accessible URL for Gate. For use with load balancers
+        # that do any kind of address manipulation for Gate traffic, such as an
+        # SSL terminating load balancer.
+        preEstablishedRedirectUri: string
+          
+        # The method used to transmit authentication credentials to your
+        # OAuth 2.0 provider; defaults to header.
+        clientAuthenticationScheme: [header|query|form|none]
+          
+        # Whether the current URI in the request should be preferred over the
+        # pre-established redirect URI.
+        useCurrentUri: boolean
+        
+      resource:
+        # The user info URI for your OAuth 2.0 provider.
+        userInfoUri: string
+        
+      # Mapping of user attributes to fields returned by your OAuth 2.0 provider.
+      # This field controls how the fields returned from the OAuth 2.0 provider's
+      # user info endpoint are translated into a Spinnaker user.
+      userInfoMapping:
+        email: string
+        firstName: string
+        lastName: string
+        username: string
+        
+      # The map of requirements the userInfo request must have. This is used to
+      # restrict user login to specific domains or to users having a specific attribute.
+      userInfoRequirements: map<string, string>
+```
+
+## Halyard CLI commands
+
+There are Halyard CLI commands to edit each field above; these are documented
+[here](https://www.spinnaker.io/reference/halyard/commands/#hal-config-security-authn-oauth2).

--- a/setup/security/authentication/oauth/github/index.md
+++ b/setup/security/authentication/oauth/github/index.md
@@ -4,12 +4,48 @@ sidebar:
   nav: setup
 ---
 
+## Get Client ID and Secret
 
-Go to https://github.com/settings/applications/new
+Consult the [GitHub OAuth 2.0 documentation](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/)
+and [register](https://github.com/settings/applications/new) a new OAuth 2.0 application
+to obtain a client ID and client secret.
+
+## Configure Halyard
+
+You may configure Halyard either with the CLI or by manually editing the hal config.
+
+### Hal config
+
+```yaml
+security:
+  authn:
+    oauth2:
+      enabled: true
+      client:
+        clientId: # client ID from above
+        clientSecret: # client secret from above
+        accessTokenUri: https://github.com/login/oauth/access_token
+        userAuthorizationUri: https://github.com/login/oauth/authorize
+        scope: user:email
+      resource:
+        userInfoUri: https://api.github.com/user
+      # You almost certainly want to restrict access to your Spinnaker by adding
+      # userInfoRequirements; otherwise any user with a GitHub account will be
+      # able to access it.
+      userInfoRequirements: {}
+      userInfoMapping:
+        email: email
+        firstName: ''
+        lastName: name
+        username: login
+      provider: GITHUB
+```
+
+### CLI
 
 ```bash
 hal config security authn oauth2 edit --provider github \
-  --client-id (client id from above) \
+  --client-id (client ID from above) \
   --client-secret (client secret from above)
 
 hal config security authn oauth2 enable

--- a/setup/security/authentication/oauth/google/index.md
+++ b/setup/security/authentication/oauth/google/index.md
@@ -7,7 +7,7 @@ sidebar:
 This page instructs you on how to obtain an OAuth 2.0 client ID and client secret for use with your G Suite organization
 (previously known as Google Apps for Work).
 
-## Get client id and secret
+## Get client ID and secret
 1. Navigate to [https://console.developers.google.com/apis/credentials](https://console.developers.google.com/apis/credentials).
 2. Click "Create credentials" --> OAuth client ID.
 3. Select "Web Application", and enter a name.
@@ -18,11 +18,41 @@ This page instructs you on how to obtain an OAuth 2.0 client ID and client secre
 ![GCP console to create OAuth 2.0 client screenshot](gcp-oauth-client.png)
 
 
+## Configure Halyard
 
-## Setup Halyard
+You may configure Halyard either with the CLI or by manually editing the hal config.
+
+### Hal config
+
+```yaml
+security:
+  authn:
+    oauth2:
+      enabled: true
+      client:
+        clientId: # client ID from above
+        clientSecret: # client secret from above
+        accessTokenUri: https://www.googleapis.com/oauth2/v4/token
+        userAuthorizationUri: https://accounts.google.com/o/oauth2/v2/auth
+        scope: profile email
+      resource:
+        userInfoUri: https://www.googleapis.com/oauth2/v3/userinfo
+      userInfoRequirements:
+        # You almost certainly want to restrict access to your Spinnaker to
+        # users whose account is from your hosted domain; without this any
+        # user with a Google account will have access.
+        hd: # hosted domain
+      userInfoMapping:
+        email: email
+        firstName: given_name
+        lastName: family_name
+      provider: GOOGLE
+```
+
+### CLI
 ```bash
 hal config security authn oauth2 edit --provider google \
-  --client-id (client id from above) \
+  --client-id (client ID from above) \
   --client-secret (client secret from above)
 
 hal config security authn oauth2 enable

--- a/setup/security/authentication/oauth/index.md
+++ b/setup/security/authentication/oauth/index.md
@@ -19,9 +19,9 @@ these fields.
 
 ## OAuth 2.0 providers
 
-Consult the documentation of your OAuth 2
-provider to determine the appropriate values to put in each configurable field. For
-some common OAuth 2.0 providers, specific documentation is provided here.
+Consult the documentation of your OAuth 2 provider to determine the appropriate
+values to put in each configurable field. For some common OAuth 2.0 providers,
+specific documentation is provided here.
 
 If you're using one of these providers, please follow the appropriate link
 below for specific instructions on configuring your provider:
@@ -94,9 +94,9 @@ userInfoMapping:
 
 User access can be restricted further based on the user info from an OAuth ID token. This
 requirement is set via the `security.authn.oauth2.userInfoRequirements` field, which
-is a map of key/value pairs. The values are interpreted as regular expressions if
-they start and end with '/'. This enables us to restrict user login to specific
-domains or users having a specific attribute.
+is a map of key/value pairs. The values are interpreted as regular expressions if they
+start and end with '/'. This enables restricting login to users from a specific domain
+or having a specific attribute.
 
 For example:
 ```yaml

--- a/setup/security/authentication/oauth/index.md
+++ b/setup/security/authentication/oauth/index.md
@@ -19,11 +19,11 @@ these fields.
 
 ## OAuth 2.0 providers
 
-In the general case, you’ll need to consult the documentation of your OAuth 2
+Consult the documentation of your OAuth 2
 provider to determine the appropriate values to put in each configurable field. For
 some common OAuth 2.0 providers, specific documentation is provided here.
 
-If you are using one of these providers, please follow the appropriate link
+If you're using one of these providers, please follow the appropriate link
 below for specific instructions on configuring your provider:
 * [Azure](./azure/)
 * [GitHub Teams](./github/)
@@ -95,7 +95,7 @@ userInfoMapping:
 User access can be restricted further based on the user info from an OAuth ID token. This
 requirement is set via the `security.authn.oauth2.userInfoRequirements` field, which
 is a map of key/value pairs. The values are interpreted as regular expressions if
-if they start and end with '/'. This enables us to restrict user login to specific
+they start and end with '/'. This enables us to restrict user login to specific
 domains or users having a specific attribute.
 
 For example:

--- a/setup/security/authentication/oauth/index.md
+++ b/setup/security/authentication/oauth/index.md
@@ -11,70 +11,65 @@ by the identity provider. To confirm your identity, Spinnaker requests access to
 from your identity provider.  Please read ALL of the documentation on this page as just setting the provider
 may not work for your environment.
 
+## Configuration
 
-## OAuth providers
+All of the OAuth 2.0 fields that can be configured in Halyard are detailed
+[here](config.md). The documentation on this page frequently refers back to
+these fields.
 
-These OAuth 2.0 providers below have been pre-configured in Spinnaker. Follow the instructions to obtain a client ID 
-and client secret.
+## OAuth 2.0 providers
 
-* [Google Apps for Work / G Suite](./google/)
-* [GitHub Teams](./github/)
+In the general case, you’ll need to consult the documentation of your OAuth 2
+provider to determine the appropriate values to put in each configurable field. For
+some common OAuth 2.0 providers, specific documentation is provided here.
+
+If you are using one of these providers, please follow the appropriate link
+below for specific instructions on configuring your provider:
 * [Azure](./azure/)
+* [GitHub Teams](./github/)
+* [Google Apps for Work / G Suite](./google/)
+* [Oracle Cloud](./oracle/)
 
-### Pre-configured providers
+## Network architecture and SSL termination
 
-For convenience, several providers are already pre-configured. As an administrator, you merely have
- to activate one, and give the client ID and secret. Follow the Provider-Specific documentation to
- obtain your client ID and client secret.
+During the OAuth [workflow](/reference/architecture/authz_authn/authentication/#workflow), Gate makes an intelligent 
+guess on how to assemble a URI to
+itself, called the *redirect URI*. Sometimes this guess is wrong when Spinnaker is deployed
+in concert with other networking components, such as an SSL-terminating load balancer, or in the
+case of the [Quickstart](/setup/quickstart) images, a fronting Apache instance.
 
-Provider | Halyard value | Provider-Specific Docs
---- | --- | ---
-Google Apps for Work / G Suite | `google` | [Google Apps for Work / G Suite](./google/)
-GitHub | `github` | [GitHub Teams](https://help.github.com/articles/authorizing-oauth-apps/){:target="\_blank"}
-Azure | `azure` | [Azure](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-code){:target="\_blank"}
-
-Activate one by executing the following:
-
-```
-CLIENT_ID=myClientId
-CLIENT_SECRET=myClientSecret
-PROVIDER=google|github|azure
-
-hal config security authn oauth2 edit \
-  --client-id $CLIENT_ID \
-  --client-secret $CLIENT_SECRET \
-  --provider $PROVIDER
-hal config security authn oauth2 enable
-```
-
-### Bring-your-own provider
-
-If you'd like to configure your own OAuth provider, you'll need to provide the following
-configuration values in your `gate-local.yml` file. If you're using Halyard, you can put this in
-a new file under your [deployment](/reference/halyard/#deployments) (typically `default`):
-`~/.hal/$DEPLOYMENT/profiles/gate-local.yml`.
-
+You can manually set the redirect URI at the `security.authn.oauth2.client.preEstablishedRedirectUri`
+field
 ```yaml
 security:
-  oauth2:
-    client:
-      clientId:
-      clientSecret:
-      userAuthorizationUri: # Used to get an authorization code
-      accessTokenUri:       # Used to get an access token
-      scope:
-    resource:
-      userInfoUri:          # Used to get the current user's email address/profile
-    userInfoMapping:        # Used to map the userInfo response to our User
-      email:
-      firstName:
-      lastName:
-      username:
+  authn:
+    oauth2:
+      client:
+        preEstablishedRedirectUri: https://my-real-gate-address.com:8084/login
+```
+or via the following `hal` command:
+```bash
+hal config security authn oauth2 edit --pre-established-redirect-uri https://my-real-gate-address.com:8084/login
 ```
 
-#### UserInfoMapping
+> Be sure to include the `/login` suffix at the end of the of your `preEstablishedRedirectUri`!
+
+Additionally, some configurations make it necessary to "unwind" external proxy instances. This makes the request to Gate
+look like the original request to the outer-most proxy. Add this to your `gate-local.yml` file in your Halyard
+[custom profile](/reference/halyard/custom/#custom-profiles):
+
+```
+server:
+  tomcat:
+    protocolHeader: X-Forwarded-Proto
+    remoteIpHeader: X-Forwarded-For
+    internalProxies: .*
+```
+
+## UserInfoMapping
+
 The `userInfoMapping` field in the configuration is used to map the names of fields from the
-`userInfoUri` request to Spinnaker-specific fields. For example, if your user profile in your OAuth
+`userInfoUri` request to Spinnaker-specific fields. For example, if your user profile in your OAuth 2.0
  provider's system looks like:
 
 ```json
@@ -95,63 +90,28 @@ userInfoMapping:
   username: user
 ```
 
-#### Enable your custom provider
-
-Configure your custom OAuth Provider in Halyard
-
-```
-CLIENT_ID=myClientId
-CLIENT_SECRET=myClientSecret
-
-hal config security authn oauth2 edit \
-  --client-id $CLIENT_ID \
-  --client-secret $CLIENT_SECRET
-```
-
-Enable the oauth2 Provider in Halyard
-
-```
-hal config security authn oauth2 enable
-```
-
-
-## Network architecture and SSL termination
-
-During the OAuth [workflow](/reference/architecture/authz_authn/authentication/#workflow), Gate makes an intelligent 
-guess on how to assemble a URI to
-itself, called the **`redirect_uri`**. Sometimes this guess is wrong when Spinnaker is deployed
-in concert with other networking components, such as an SSL-terminating load balancer, or in the
-case of the [Quickstart](/setup/quickstart) images, a fronting Apache instance.
-
-To manually set the `redirect_uri` for Gate, use the following `hal` command:
-
-```bash
-hal config security authn oauth2 edit --pre-established-redirect-uri https://my-real-gate-address.com:8084/login
-```
-
-> Be sure to include the `/login` suffix at the end of the `--pre-established-redirect-uri` flag!
-
-Additionally, some configurations make it necessary to "unwind" external proxy instances. This makes the request to Gate
-look like the original request to the outer-most proxy. Add this to your `gate-local.yml` file in your Halyard
-[custom profile](/reference/halyard/custom/#custom-profiles):
-
-```
-server:
-  tomcat:
-    protocolHeader: X-Forwarded-Proto
-    remoteIpHeader: X-Forwarded-For
-    internalProxies: .*
-```
-
 ## Restricting access based on User Info
 
 User access can be restricted further based on the user info from an OAuth ID token. This
-requirement is set via the `--user-info-requirements` parameter. This enables us to restrict user
-login to specific domains or having a specific attribute. Use equal signs between key and value,
-and additional key/value pairs need to repeat the flag. The values can also be regex expressions
-if they start and end with '/'.
+requirement is set via the `security.authn.oauth2.userInfoRequirements` field, which
+is a map of key/value pairs. The values are interpreted as regular expressions if
+if they start and end with '/'. This enables us to restrict user login to specific
+domains or users having a specific attribute.
+
+For example:
+```yaml
+security:
+  authn:
+    oauth2:
+      userInfoRequirements:
+        hd: your-org.net
+        batz: /^Sample.*Regex/
+        foo: bar
 ```
-# Example:
+
+To set this field with the Halylard CLI, use equal signs between key and value and
+repeat the flag to specify multiple values:
+```
 hal config security authn oauth2 edit \
   --user-info-requirements hd=your-org.net \
   --user-info-requirements batz=/^Sample.*Regex/ \

--- a/setup/security/authentication/oauth/oracle/index.md
+++ b/setup/security/authentication/oauth/oracle/index.md
@@ -1,0 +1,52 @@
+---
+title:  "Oracle Cloud"
+sidebar:
+  nav: setup
+---
+
+## Configuring Oracle Cloud OAuth 2.0
+
+Consult the [Oracle Cloud Documentation](https://docs.oracle.com/en/cloud/get-started/subscriptions-cloud/ocuid/introduction-oauth-oracle-cloud.html)
+to set up OAuth 2.0 and obtain a client ID and client secret.
+
+## Configure Halyard
+
+You may configure Halyard either with the CLI or by manually editing the hal config.
+
+### Hal config
+
+```yaml
+security:
+  authn:
+    oauth2:
+      enabled: true
+      client:
+        clientId: # client ID from above
+        clientSecret: # client secret from above
+        accessTokenUri: https://idcs-${idcsTenantId}.identity.oraclecloud.com/oauth2/v1/token
+        userAuthorizationUri: https://idcs-${idcsTenantId}.identity.oraclecloud.com/oauth2/v1/authorize
+        scope: openid urn:opc:idm:__myscopes__
+      resource:
+        userInfoUri: https://idcs-${idcsTenantId}.identity.oraclecloud.com/oauth2/v1/userinfo
+      # You may want to restrict access to your Spinnaker by adding
+      # userInfoRequirements to further restrict access beyond simply requiring
+      # that users have a valid account.
+      userInfoRequirements: {}
+      userInfoMapping:
+        email: ''
+        firstName: given_name
+        lastName: family_name
+        username: preferred_username
+      provider: ORACLE
+```
+
+### CLI
+
+```bash
+hal config security authn oauth2 edit --provider oracle \
+  --client-id (client ID from above) \
+  --client-secret (client secret from above)
+
+hal config security authn oauth2 enable
+
+```


### PR DESCRIPTION
Currently there is a lot of logic baked into Halyard commands to automatically set fields in the OAuth 2.0 config. While in some cases it might make set-up easier, it comes at the expense of the ability to see and modify what is being configured.

Kleat will not replicate this behavior; it will not store a mapping of the token URI for a number of common OAuth 2.0 providers; users will need to set this themselves in their YAML config. In order to make this easier, let's improve the documentation so that it's easy for users to set up any OAuth 2.0 provider by just pasting in the provided YAML and configuring as necessary.

I think this will actually make it easier for users to troubleshoot as it will be more clear to them what fields they have set (rather than having this done behind the scenes).

This commit:
(1) Adds full documentation on the OAuth 2.0 config; it is currently copy-pasted from the source of truth protos, but once kleat is more mature we can probably just link out to its documentation. (I don't want a consumer of the documentation yet so we are more free to refactor it as we'll likely think about once all the protos are written).
(2) Augments all the inline hal commands with documentation on how to configure something by editing your YAML. (I actually think this will be more clear to operators familiar with YAML than the hal commands.)
(3) Updates the provider-specific documentation to include a block of YAML including what Halyard defaulted and kleat will not default.
(4) Updates references to all say OAuth 2.0 for consistency (fixing the mix of OAuth2 Oauth2 OAuth 2 and OAuth 2.0).

Users using Halyard can use either the YAML-editing or CLI instructions; users using kleat will need to use the YAML-editing instructions. (Though given that kleat is not even alpha yet I have not mentioned it at all here, we'll need to holistically update the docs when it's ready for users.)