### PR TITLE
feat(docs): clarify language around release windows

### DIFF
--- a/community/releases/release-cadence/index.md
+++ b/community/releases/release-cadence/index.md
@@ -6,17 +6,16 @@ sidebar:
 
 {% include toc %}
 
-As of the 1.6 release, the Spinnaker team is committed to providing a more
-regular release cadence in order to help users understand when new features
-will be available, as well help non-core developers plan to get their features
-released in the next stable version of Spinnaker.
+The Spinnaker team is committed to providing a regular release cadence in order
+to help users understand when new features will be available, as well as help
+non-core developers plan to get their features released in the next stable
+version of Spinnaker.
 
-## Release Window
+## Cutting the Release Branches
 
-Every eight weeks we open the Release Window, meaning that we cut release
-branches for the upcoming release. If the version we intend to release is
-`M.N`, a branch with the name `release-M.N.x` is cut in each component
-repository. For example, see the state of the
+Every eight weeks, we cut release branches for the upcoming release. If the
+version we intend to release is `M.N`, a branch with the name `release-M.N.x` is
+cut in each component repository. For example, see the state of the
 [Clouddriver](https://github.com/spinnaker/clouddriver/) repository leading up
 to the 1.6 release:
 
@@ -55,14 +54,15 @@ hal deploy apply
 If you've found a fix for a bug in the Release Candidate, follow the [patching
 procedure described
 here](/community/contributing/releasing/#merge-into-the-release-branch). If
-your patch is merged before the [Release Window is
-closed](#closing-the-release-window), it will be included in this release.
+your patch is merged before the [release candidate is marked
+stable](#marking-the-release-candidate-stable), it will be included in this
+release.
 
 Unless a severe error (e.g. security vulnerability, large-scale breakage) has a
 pending patch, patch releases are published at a weekly cadence on a
 best-effort basis.
 
-### Closing the Release Window
+### Marking the Release Candidate Stable
 
 Once the community has deemed that the Candidate is "stable" (meaning all
 [integration
@@ -71,14 +71,14 @@ passing, and no known issues or regressions remain), we will release Spinnaker
 at version `M.N.0`. Further patches can be merged into the release branch for
 future patch releases (e.g. `M.N.1`).
 
-## Upcoming Release Windows
+## Upcoming Releases
 
-| Version | Window Opens | Release Manager (Slack ID) |
+| Version | Release Branches Cut | Release Manager (Slack ID) |
 |-|-|-|
 | `1.20.0` | 2020-04-27 | Ethan Rogers (@ethanfrogers)
-| `1.21.0` | 2020-06-22 | TBD
-| `1.22.0` | 2020-08-17 | TBD
-| `1.23.0` | 2020-10-12 | TBD
+| `1.21.0` | 2020-06-23 | TBD
+| `1.22.0` | 2020-08-18 | TBD
+| `1.23.0` | 2020-10-13 | TBD
 
-> Keep in mind, when the window opens, the release candidate becomes available.
-> The actual release happens one to two weeks later.
+> Keep in mind, when the release branches are cut, the release candidate becomes
+> available. The stable release becomes available one to two weeks later.

--- a/community/releases/release-manager-runbook/index.md
+++ b/community/releases/release-manager-runbook/index.md
@@ -7,17 +7,17 @@ sidebar:
 
 {% include toc %}
 
-## Friday before the release window opens
+## One week before the branches are cut (Monday)
 
 Ping [#dev](https://spinnakerteam.slack.com/messages/dev/) reminding everyone
 to merge outstanding changes by Monday:
 
-> The release manager will be cutting the $VERSION release branches on Tuesday,
+> The release manager will be cutting the $VERSION release branches next Tuesday,
 > so if there are any outstanding PRs that you'd like to get into $VERSION,
-> please make sure they are merged by EOD Monday. Once the branch is cut, only
-> fixes will be accepted into the release branches.
+> please make sure they are merged by EOD next Monday. Once the branch is cut,
+> only fixes will be accepted into the release branches.
 
-## First Monday of the release window
+## One day before the branches are cut (Monday)
 
 Ping [#dev](https://spinnakerteam.slack.com/messages/dev/) reminding everyone
 to merge outstanding changes ASAP:
@@ -27,7 +27,7 @@ to merge outstanding changes ASAP:
 > $VERSION, please make sure they are merged ASAP. Once the branch is cut, only
 > fixes will be accepted into the release branches.
 
-## First Tuesday of the release window
+## The day the branches are cut (Tuesday)
 
 1. Reach out to anyone who has previously contacted you to ensure their
 last-minute release PRs have been merged.
@@ -100,25 +100,25 @@ newest release branch, and remove the row for the oldest release branch.
 1. Ping [#dev](https://spinnakerteam.slack.com/messages/dev/) with some version of
 this message, including a link to the correct section of the changelog gist:
 
-    > The release window for Spinnaker $VERSION is now open!  This means that
-    > release branches have been cut from master and those branches are only
-    > accepting fixes for existing features.  Please contact $YOUR_NAME
-    > (slack: $YOUR_SLACK_ID, github: $YOUR_GITHUB_ID, or email: $YOUR_EMAIL) if you
-    > would like a fix cherry-picked into the release. If you would like to highlight
-    > a specific fix or feature in the release’s changelog, please make a pull
-    > request against the [curated changelog](/community/releases/next-release-preview)
+    > The release branches for Spinnaker $VERSION have been cut from master!
+    > Those branches are only accepting fixes for existing features.  Please
+    > contact $YOUR_NAME (slack: $YOUR_SLACK_ID, github: $YOUR_GITHUB_ID, or
+    > email: $YOUR_EMAIL) if you would like a fix cherry-picked into the
+    > release. If you would like to highlight a specific fix or feature in the
+    > release’s changelog, please make a pull request against the
+    > [curated changelog](/community/releases/next-release-preview)
     > by Friday. If you’d like to jog your memory of everything to be released
     > with Spinnaker $VERSION, see the raw changelog here: $LINK_TO_CHANGELOG.
 
 1. When the Flow_BuildAndValidate_${RELEASE} job passes, ping
-[#dev](https://spinnakerteam.slack.com/messages/dev/) with a message that
+[#dev](https://spinnakerteam.slack.com/messages/dev/) with a message that the
 release candidate is now validated and can be tested by running:
 
     ```
     hal config version edit --version ${RELEASE_BRANCH}-latest-validated
     ```
 
-## Second Monday of the release window
+## One week after branches are cut (Monday)
 
 1. Check for any PRs waiting to be [cherry-picked](https://github.com/pulls?utf8=%E2%9C%93&q=org%3Aspinnaker+is%3Apr+is%3Aopen+-base%3Amaster).
 (You can further restrict the query by adding a constraint like +base:release-1.18.x to the URL.)

--- a/community/releases/release-manager-runbook/index.md
+++ b/community/releases/release-manager-runbook/index.md
@@ -29,9 +29,6 @@ to merge outstanding changes ASAP:
 
 ## The day the branches are cut (Tuesday)
 
-1. Reach out to anyone who has previously contacted you to ensure their
-last-minute release PRs have been merged.
-
 1. If there are any [outstanding autobump PRs](https://github.com/pulls?q=is%3Apr+author%3Aspinnakerbot+is%3Aopen),
 make the required fixes to allow them to merge.
 


### PR DESCRIPTION
Per our release 1.20 retro today:

- Replace unclear "release window" language with specific references to dates for release branches being cut and candidate/stable releases being made available.
- Push first step of runbook back to one week prior to branches being cut to give contributors more notice.