### PR TITLE
docs(sql): Add clouddriver read-only setting

### DIFF
--- a/setup/productionize/persistence/clouddriver-sql.md
+++ b/setup/productionize/persistence/clouddriver-sql.md
@@ -68,6 +68,10 @@ The following yaml-based parameters provide a Clouddriver configuration that ent
 ```yaml
 sql:
   enabled: true
+  # read-only boolean toggles `SELECT` or `DELETE` health checks for all pools.
+  # Especially relevant for clouddriver-ro and clouddriver-ro-deck which can
+  # target a SQL read replica in their default pools.
+  read-only: false 
   taskRepository:
     enabled: true
   cache:


### PR DESCRIPTION
This is likely required when using SQL backing for clouddriver with both
master and read-only replicas.

Closes #1845 