### PR TITLE
fix variable typo in pipeline templates instantiate

### DIFF
--- a/guides/user/pipeline/pipeline-templates/instantiate.md
+++ b/guides/user/pipeline/pipeline-templates/instantiate.md
@@ -43,7 +43,7 @@ and get it using the following command:
        "type": "front50/pipelineTemplate", # Static constant
      },
      "variables": {
-       "waitTime": 4 # Value for the template variable.
+       "timeToWait": 4 # Value for the template variable.
      },
      "exclude": [],
      "triggers": [],


### PR DESCRIPTION
Reported in the spinnaker slack
https://spinnakerteam.slack.com/archives/C091CCWRJ/p1591875796073900

the current setup results in an error when following the docs verbatim: 

```
$ spin pipeline-templates plan --file pipeline.json
Status: 400 , Body: {"timestamp":1591869928537,"status":400,"error":"Bad Request","message":"400 ","body":"{\"timestamp\":1591869928534,\"status\":400,\"error\":\"Bad Request\",\"message\":\"Missing template variable values for the following variables: %s\",\"errors\":[\"timeToWait\"]}","url":"http://orca:8083/v2/pipelineTemplates/plan"}
```

This setup seems to work:

```
spin pipeline-templates plan --file pipeline.json
{
 "application": "matt-test",
 "description": "",
 "id": "unknown",
 "keepWaitingPipelines": false,
 "lastModifiedBy": "anonymous",
 "limitConcurrent": true,
 "name": "matt-wait-tester-p",
 "notifications": [],
 "parameterConfig": [],
 "source": {
  "type": "templatedPipeline",
  "version": "v2"
 },
 "stages": [
  {
   "name": "My Wait Stage",
   "notifications": [],
   "refId": "wait1",
   "requisiteStageRefIds": [],
   "type": "wait",
   "waitTime": 4
  }
 ],
 "templateVariables": {
  "timeToWait": 4
 },
 "triggers": [],
 "updateTs": "0"
}
```

As the `create` docs use this value
https://github.com/spinnaker/spinnaker.github.io/blame/master/guides/user/pipeline/pipeline-templates/create.md#L120
