### PR TITLE
fix(docs): Change URL of Service Account manifest for kubernetes

### DIFF
--- a/setup/install/providers/kubernetes-v2/aws-eks.md
+++ b/setup/install/providers/kubernetes-v2/aws-eks.md
@@ -137,7 +137,7 @@ CONTEXT=$(kubectl config current-context)
 Next, create a service account for the Amazon EKS cluster:
 
 ```
-kubectl apply --context $CONTEXT -f https://spinnaker.io/downloads/kubernetes/service-account.yml
+kubectl apply --context $CONTEXT -f https://www.spinnaker.io/downloads/kubernetes/service-account.yml
 ```
 
 See the [Kubernetes documentation for more details on service accounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/).

--- a/setup/install/providers/kubernetes-v2/index.md
+++ b/setup/install/providers/kubernetes-v2/index.md
@@ -61,7 +61,7 @@ CONTEXT=$(kubectl config current-context)
 # This service account uses the ClusterAdmin role -- this is not necessary, 
 # more restrictive roles can by applied.
 kubectl apply --context $CONTEXT \
-    -f https://spinnaker.io/downloads/kubernetes/service-account.yml
+    -f https://www.spinnaker.io/downloads/kubernetes/service-account.yml
 
 TOKEN=$(kubectl get secret --context $CONTEXT \
    $(kubectl get serviceaccount spinnaker-service-account \


### PR DESCRIPTION
"https://spinnaker.io" isn't able to connect to the server
x509: certificate is valid for www.github.com, *.github.com, ..., not spinnaker.io

This PR will correct the URL to the "https://www.spinnaker.io"