### PR TITLE
feat(docs): add suspended cloud providers to 1.21 Release Preview

### DIFF
--- a/community/releases/next-release-preview/index.md
+++ b/community/releases/next-release-preview/index.md
@@ -18,3 +18,16 @@ changelog.
 1.20 was the final release to include support for Spinnaker's legacy Kubernetes
 (V1) provider. Please migrate all Kubernetes accounts to the standard (V2)
 provider before upgrading to Spinnaker 1.21.
+
+### Suspension of Support for Alicloud, DC/OS, and Oracle Cloud Providers
+
+The Alicloud, DC/OS, and Oracle cloud providers are excluded from 1.21 because
+they no longer meet Spinnaker's
+[cloud provider requirements](https://github.com/spinnaker/governance/blob/master/cloud-provider-requirements.md),
+which include the formation of a Spinnaker SIG. If you are interested in
+forming a SIG for one of these cloud providers, please comment on the
+appropriate GitHub issue:
+
+* [Alicloud](https://github.com/spinnaker/governance/issues/122)
+* [DC/OS](https://github.com/spinnaker/governance/issues/125)
+* [Oracle](https://github.com/spinnaker/governance/issues/127)


### PR DESCRIPTION
Since we have [removed](https://github.com/spinnaker/clouddriver/pull/4646 ) Alicloud, DC/OS, and Oracle from the OSS build, let's make sure this ends up at the top of the 1.21 curated changelog. I will also submit a PR to remove these providers from Deck's build so end-users realize these providers are suspended as quickly as possible.