### PR TITLE
Update to point to RBAC Auth

### DIFF
--- a/guides/user/pipeline/triggers/webhooks/index.md
+++ b/guides/user/pipeline/triggers/webhooks/index.md
@@ -21,7 +21,7 @@ If you're triggering from a *GitHub* webhook, see the instructions
 [here](/setup/triggers/github/) to set up that webhook.
 
 If you're triggering to a Spinnaker with authentication, see the 
-instructions [here](/setup/security/authorization/) to set up the 
+instructions [here](/setup/security/authorization/#automated-pipeline-triggers) to set up the 
 automated trigger.
 
 ## Adding a webhook trigger to a pipeline

--- a/guides/user/pipeline/triggers/webhooks/index.md
+++ b/guides/user/pipeline/triggers/webhooks/index.md
@@ -20,6 +20,10 @@ you, will be available in the Pipeline's execution.
 If you're triggering from a *GitHub* webhook, see the instructions
 [here](/setup/triggers/github/) to set up that webhook.
 
+If you're triggering to a spinnaker with authentication, see the 
+instructions [here](/setup/security/authorization/) to set up the 
+automated trigger.
+
 ## Adding a webhook trigger to a pipeline
 
 Assuming you have created a pipeline, under __Configuration__, select __Add

--- a/guides/user/pipeline/triggers/webhooks/index.md
+++ b/guides/user/pipeline/triggers/webhooks/index.md
@@ -20,7 +20,7 @@ you, will be available in the Pipeline's execution.
 If you're triggering from a *GitHub* webhook, see the instructions
 [here](/setup/triggers/github/) to set up that webhook.
 
-If you're triggering to a spinnaker with authentication, see the 
+If you're triggering to a Spinnaker with authentication, see the 
 instructions [here](/setup/security/authorization/) to set up the 
 automated trigger.
 


### PR DESCRIPTION
This is just to make a call out that if your pipelines have roles assigned to them you want to make sure you configure auth for your triggers as well.