### PR TITLE
docs(fix): add content to section index pages

### DIFF
--- a/guides/developer/dev-env/index.md
+++ b/guides/developer/dev-env/index.md
@@ -5,3 +5,9 @@ sidebar:
   nav: guides
 ---
 
+This section contains the following content:
+
+* [Common Internals](/guides/developer/dev-env/common-internals/): Spinnaker is built as a collection of microservices, all of these services share a common foundation. This page enumerates, at a high-level, what foundations the Spinnaker services are built atop.
+* [Kork Library](/guides/developer/dev-env/kork-library/): Kork is a common library used across multiple Spinnaker components. This guide is meant for developers who need to make changes to Kork, test those changes locally in the component that relies on those changes, and deploy those changes once they've been submitted.
+* [Getting Set Up for Spinnaker Development](/guides/developer/dev-env/getting-set-up/): This page describes the steps a Developer should take to fetch Spinnaker's codebase and get set up to work on it.
+* [Getting Set Up for Spinnaker Development on AWS](/guides/developer/dev-env/provider-setups/aws-dev-setup/): This guide describes how a developer can set up a Local Git deployment of Spinnaker on Amazon EC2.

--- a/guides/developer/extending/index.md
+++ b/guides/developer/extending/index.md
@@ -5,4 +5,7 @@ sidebar:
   nav: guides
 ---
 
-{% include toc %}
+This section contains the following content:
+
+* [Kubernetes CRD Extensions](/guides/developer/extending/crd-extensions):  Explains extension points for deep CRD integrations within Spinnaker.
+* [Writing a New Stage](/guides/developer/extending/new-stage/): To create a new stage, you need to make backend changes to Orca to implement the logic of the stage and to Deck to implement the UI. This doc covers the backend changes made to Orca.

--- a/guides/developer/plugin-creators/index.md
+++ b/guides/developer/plugin-creators/index.md
@@ -5,3 +5,8 @@ sidebar:
   nav: guides
 ---
 
+This section contains the following content:
+
+* [Overview](/guides/developer/plugin-creators/overview/):  Explains the types of plugins you can use with Spinnaker.
+* [Plugin Project Configuration](/guides/developer/plugin-creators/project-config): _Work in Progress_ Plugins are an evolving feature.  The easiest way to set up a new plugin project is to copy one of the [spinnaker-plugin-examples](https://github.com/spinnaker-plugin-examples) projects that most closely resembles what you want to do.
+* [Test a Pipeline Stage Plugin](/guides/developer/plugin-creators/deck-plugin/): This guide explains how to set up a local Spinnaker environment on your Mac or Windows environment so you can test the `pf4jStagePlugin`, which has both Orca and Deck components. Spinnaker services running locally communicate with the other Spinnaker services running in a local VM. Although this guide is specific to the `pf4jStagePlugin`, you can adapt its contents to test your own plugin.


### PR DESCRIPTION
Add content to section index pages in case users click on the breadcrumbs instead of the left navigation tree.

Fixes: https://github.com/spinnaker/spinnaker.github.io/issues/1925