### PR TITLE
docs(fix): Add redirect to fix plugins/user-guide 404

### DIFF
--- a/guides/user/plugins/index.md
+++ b/guides/user/plugins/index.md
@@ -5,6 +5,7 @@ sidebar:
   nav: guides
 redirect_from:
   - /guides/user/plugin-users/
+  - /guides/user/plugins/user-guide
 ---
 
 {% include alpha version="1.20.6" %}


### PR DESCRIPTION
Google search turns up this result:   https://spinnaker.io/guides/user/plugins/user-guide/  which gives a 404