### PR TITLE
docs(gardening): Removing -n namespace

### DIFF
--- a/community/gardening/spin-contrib.md
+++ b/community/gardening/spin-contrib.md
@@ -139,7 +139,7 @@ For example, if your `namespace` is "aimee", change `gardening-days-FIXME` to `g
 
 Save the file.
 
-Export your KUBECONFIG file and `kubectl apply` the `spinsvc.yaml` custom resource definition to install Spinnaker. You only have access to your namespace, so you do not need to include the `-n <namespace>` parameter.
+Export your KUBECONFIG file and `kubectl apply` the `spinsvc.yaml` custom resource definition to install Spinnaker. _You only have access to your namespace, so you do not need to include the `-n <namespace>` parameter._
 
 ```bash
 kubectl --kubeconfig ~/.kube/<kube-config-file-name>.yaml apply -f <spinnaker-service-file>.yaml

--- a/community/gardening/spin-contrib.md
+++ b/community/gardening/spin-contrib.md
@@ -176,13 +176,13 @@ spin-rosco-79b55d5c99-zkq4w         0/1     ContainerCreating   0          22s
 In your current Terminal window, forward the Deck port:
 
 ```bash
-kubectl --kubeconfig ~/.kube/garden.yaml -n <your-namespace-name> port-forward svc/spin-deck 9000
+kubectl --kubeconfig ~/.kube/garden.yaml port-forward svc/spin-deck 9000
 ```
 
 Open another Terminal session and forward the Gate port:
 
 ```bash
-kubectl --kubeconfig ~/.kube/garden.yaml -n <your-namespace-name> port-forward svc/spin-gate 8084
+kubectl --kubeconfig ~/.kube/garden.yaml port-forward svc/spin-gate 8084
 ```
 
 ## Start Telepresence for the local Orca service
@@ -191,7 +191,7 @@ In a new Terminal session, change to the Orca directory and start Telepresence:
 
 ```
 cd <path-to-orca-clone>
-KUBECONFIG=~/.kube/garden.yaml telepresence --namespace <your-namespace-name> --swap-deployment spin-orca --env-file .env-telepresence
+KUBECONFIG=~/.kube/garden.yaml telepresence --swap-deployment spin-orca --env-file .env-telepresence
 ```
 
 You may see a permission error on OSX similar to:


### PR DESCRIPTION
It is unneeded because it is defined in the garden.yaml provided by armory