### PR TITLE
Fix "GitHub Team" authn to "GitHub Organization"

### DIFF
--- a/index.md
+++ b/index.md
@@ -83,7 +83,7 @@ notifications_feature:
   content: "Set up event notifications for email, Slack, HipChat, or SMS (via Twilio)."
 access_control_feature:
   title: Role-based Access Control
-  content: "Restrict access to projects or accounts by hooking into your internal authentication system using OAuth, SAML, LDAP, X.509 certs, Google groups, Azure groups, or GitHub teams."
+  content: "Restrict access to projects or accounts by hooking into your internal authentication system using OAuth, SAML, LDAP, X.509 certs, Google groups, Azure groups, or GitHub Organizations."
 manual_judgments_feature:
   title: Manual Judgments
   content: "Require a manual approval prior to releasing an update with a manual judgement stage."

--- a/setup/security/authentication/oauth/index.md
+++ b/setup/security/authentication/oauth/index.md
@@ -26,7 +26,7 @@ specific documentation is provided here.
 If you're using one of these providers, please follow the appropriate link
 below for specific instructions on configuring your provider:
 * [Azure](./azure/)
-* [GitHub Teams](./github/)
+* [GitHub Organization](./github/)
 * [Google Apps for Work / G Suite](./google/)
 * [Oracle Cloud](./oracle/)
 

--- a/setup/security/authorization/index.md
+++ b/setup/security/authorization/index.md
@@ -58,7 +58,7 @@ both permissions to perform certain actions.
 * An external role provider from one of the following:
     * Google Groups via a G Suite Account
         * With access to the G Suite Admin console
-    * GitHub Team
+    * GitHub Organization
     * LDAP server
     * SAML Identity Provider (IdP) that includes groups in the assertion
         > SAML roles are fixed at login time, and cannot be changed until the user needs to


### PR DESCRIPTION
## Why

For Spinnaker authentication, the GitHub Organization is used not GitHub Team. 
Therefore, I think the current document is misleading.