### PR TITLE
New title AWS compute services & improved wording

### DIFF
--- a/setup/install/providers/aws/index.md
+++ b/setup/install/providers/aws/index.md
@@ -7,8 +7,8 @@ sidebar:
 
 {% include toc %}
 
-### AWS Compute with the Spinnaker AWS Cloud Provider
-The AWS Cloud Provider allows Spinnaker to release artifacts in some of the [AWS compute services](https://aws.amazon.com/products/compute/) with Spinnaker.
+## AWS Compute with the Spinnaker AWS Cloud Provider
+The AWS Cloud Provider allows Spinnaker to release artifacts in some of the [AWS compute services](https://aws.amazon.com/products/compute/)
 
 There are several ways to configure the Amazon Web Services (AWS) Cloud Provider. Choose one or more based on your requirements:
 
@@ -17,7 +17,8 @@ There are several ways to configure the Amazon Web Services (AWS) Cloud Provider
 * [Amazon Elastic Kubernetes Service (EKS)](/setup/install/providers/kubernetes-v2/aws-eks/) - Use this option, if you want to manage containers in [AWS EKS](https://aws.amazon.com/eks/). This option uses [Kubernetes V2 (manifest based) Clouddriver](/setup/install/providers/kubernetes-v2)
 * [Amazon Lambda (Lambda)](https://aws.amazon.com/blogs/opensource/how-to-integrate-aws-lambda-with-spinnaker/) - Use this option, if you want to enable [AWS Lambda](https://aws.amazon.com/lambda/) support 
 
-### Concepts
+## AWS IAM Permissions with the AWS Cloud Provider
+AWS controls the permissions with AWS IAM Identity Access Management. Spinnaker functionality with AWS requires an AWS IAM structure to be ready in the AWS target accounts.
 
 There are two types of Accounts in the Spinnaker AWS provider: __AWS Managing__ account and __AWS Managed__ account(s).
 

--- a/setup/install/providers/aws/index.md
+++ b/setup/install/providers/aws/index.md
@@ -7,6 +7,16 @@ sidebar:
 
 {% include toc %}
 
+### AWS Compute with the Spinnaker AWS Cloud Provider
+The AWS Cloud Provider allows Spinnaker to release artifacts in some of the [AWS compute services](https://aws.amazon.com/products/compute/) with Spinnaker.
+
+There are several ways to configure the Amazon Web Services (AWS) Cloud Provider. Choose one or more based on your requirements:
+
+* [Amazon Elastic Compute Cloud (EC2)](/setup/install/providers/aws/aws-ec2/) - - Use this option, if you want to manage [AWS EC2](https://aws.amazon.com/ec2/) via Spinnaker
+* [Amazon Elastic Container Service (ECS)](/setup/install/providers/aws/aws-ecs/) - - Use this option, if you want to manage containers in [AWS ECS](https://aws.amazon.com/ecs/)
+* [Amazon Elastic Kubernetes Service (EKS)](/setup/install/providers/kubernetes-v2/aws-eks/) - Use this option, if you want to manage containers in [AWS EKS](https://aws.amazon.com/eks/). This option uses [Kubernetes V2 (manifest based) Clouddriver](/setup/install/providers/kubernetes-v2)
+* [Amazon Lambda (Lambda)](https://aws.amazon.com/blogs/opensource/how-to-integrate-aws-lambda-with-spinnaker/) - Use this option, if you want to enable [AWS Lambda](https://aws.amazon.com/lambda/) support 
+
 ### Concepts
 
 There are two types of Accounts in the Spinnaker AWS provider: __AWS Managing__ account and __AWS Managed__ account(s).
@@ -33,10 +43,3 @@ Refer to [AWS IAM Providing Access to multiple AWS Accounts](https://docs.aws.am
    __Example:__ AWS __Managing__ account `spinnakermanaging` can assume the __Managed__ role in the accounts __*accountdev*__, __*accountstaging*__, __*accountprod*__ and deploy a baked AMI in the pipeline.
 
 ![Example diagram of managing and managed roles](concepts.png)
-
-
-There are several ways to configure the Amazon Web Services (AWS) Cloud Provider. Choose one or more based on your requirements:
-
-* [Amazon Elastic Compute Cloud (EC2)](/setup/install/providers/aws/aws-ec2/) - - Use this option, if you want to manage [EC2 Instances](https://aws.amazon.com/ec2/) via Spinnaker
-* [Amazon Elastic Container Service (ECS)](/setup/install/providers/aws/aws-ecs/) - Use this option, if you want to manage containers in [Amazon ECS](https://aws.amazon.com/ecs/)
-* [Amazon Elastic Kubernetes Service (EKS)](/setup/install/providers/kubernetes-v2/aws-eks/) - Use this option, if you want to manage containers in [Amazon EKS](https://aws.amazon.com/eks/). This option uses [Kubernetes V2 (manifest based) Clouddriver](/setup/install/providers/kubernetes-v2)


### PR DESCRIPTION
i moved the new title AWS Compute with the Spinnaker AWS Cloud Provider to the top
i added a link to an official AWS lambda and spinnaker
this sets the stage for new Spinnaker docs on AWS Lambda
the concepts block is at the bottom.
In a future PR i will improve the wording of concepts as it requires some more detail