### PR TITLE
changed the title and a 1 line description

### DIFF
--- a/setup/install/providers/aws/aws-ec2.md
+++ b/setup/install/providers/aws/aws-ec2.md
@@ -9,7 +9,9 @@ sidebar:
 
 > :warning: These instructions are out-of-date and a new version is being
 > worked on. In the meantime, please use the following
-> [AWS install tutorial](https://aws.amazon.com/blogs/opensource/continuous-delivery-spinnaker-amazon-eks/).
+> [AWS tutorial: Continuous Delivery using Spinnaker on Amazon EKS](https://aws.amazon.com/blogs/opensource/continuous-delivery-spinnaker-amazon-eks/).
+
+The AWS EC2 Provider is used if you want to manage EC2 Instances via Spinnaker. Refer to the AWS Cloud Provider [Overview to](https://spinnaker.io/setup/install/providers/aws/) understand how AWS IAM must be set up for the AWS EC2 provider to work.
 
 In [AWS](https://aws.amazon.com/){:target="\_blank"}, an [__Account__](/concepts/providers/#accounts)
 maps to a credential able to authenticate against a given [AWS

--- a/setup/install/providers/aws/aws-ec2.md
+++ b/setup/install/providers/aws/aws-ec2.md
@@ -11,7 +11,7 @@ sidebar:
 > worked on. In the meantime, please use the following
 > [AWS tutorial: Continuous Delivery using Spinnaker on Amazon EKS](https://aws.amazon.com/blogs/opensource/continuous-delivery-spinnaker-amazon-eks/).
 
-The AWS EC2 Provider is used if you want to manage EC2 Instances via Spinnaker. Refer to the AWS Cloud Provider [Overview to](https://spinnaker.io/setup/install/providers/aws/) understand how AWS IAM must be set up for the AWS EC2 provider to work.
+Use the AWS EC2 Provider if you want to manage EC2 Instances via Spinnaker. Refer to the [AWS Cloud Provider Overview](https://spinnaker.io/setup/install/providers/aws/) to understand how AWS IAM must be set up for the AWS EC2 provider to work.
 
 In [AWS](https://aws.amazon.com/){:target="\_blank"}, an [__Account__](/concepts/providers/#accounts)
 maps to a credential able to authenticate against a given [AWS


### PR DESCRIPTION
I changed the title to include the name of the AWS EKS tutorial
I added a 1 line description. The AWS EC2 provider is part of the AWS Cloud Provider and 
is used to manage AWS EC2 instances.
Hopefully this will help in my goal to re-accomodate this doc.