### PR TITLE
feat(artifacts): update gitrepo configuration

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -124,6 +124,8 @@ setup:
             url: /setup/artifacts/github/
           - title: GitLab
             url: /setup/artifacts/gitlab/
+          - title: Git Repo
+            url: /setup/artifacts/gitrepo/
           - title: Google Cloud Storage
             url: /setup/artifacts/gcs/
           - title: HTTP

--- a/guides/user/kubernetes-v2/kustomize-manifests/index.md
+++ b/guides/user/kubernetes-v2/kustomize-manifests/index.md
@@ -113,7 +113,7 @@ As of 1.17, [git/repo](/reference/artifacts/types/git-repo/) is the only support
 
 Pipelines configured to use Kustomize in 1.16 will continue to work in 1.17. However, editing a `Bake (Manifest)` stage in 1.17, which was originally created in 1.16, requires you to update the `Bake (Manifest) Configuration` to use the `git/repo` artifact type.  To do so, use the following instructions:
 
-1. Click on the `Account` dropdown and select a configured `git/repo` account.  If none appear, make sure you have [configured a git/repo account](/reference/artifacts/types/git-repo/#configuration)  
+1. Click on the `Account` dropdown and select a configured `git/repo` account.  If none appear, make sure you have [configured a git/repo account](/reference/artifacts/types/gitrepo)  
 __Note:__ You should click and select a `git/repo` account even if one already appears in the UI prior to your doing so. This will force the underlying JSON to be updated to use the new artifact. 
 
 1. Update the URL. This should be the location of the git repository.  

--- a/guides/user/kubernetes-v2/kustomize-manifests/index.md
+++ b/guides/user/kubernetes-v2/kustomize-manifests/index.md
@@ -113,7 +113,7 @@ As of 1.17, [git/repo](/reference/artifacts/types/git-repo/) is the only support
 
 Pipelines configured to use Kustomize in 1.16 will continue to work in 1.17. However, editing a `Bake (Manifest)` stage in 1.17, which was originally created in 1.16, requires you to update the `Bake (Manifest) Configuration` to use the `git/repo` artifact type.  To do so, use the following instructions:
 
-1. Click on the `Account` dropdown and select a configured `git/repo` account.  If none appear, make sure you have [configured a git/repo account](/reference/artifacts/types/gitrepo)  
+1. Click on the `Account` dropdown and select a configured `git/repo` account.  If none appear, make sure you have [configured a git/repo account](/reference/artifacts/types/git-repo)  
 __Note:__ You should click and select a `git/repo` account even if one already appears in the UI prior to your doing so. This will force the underlying JSON to be updated to use the new artifact. 
 
 1. Update the URL. This should be the location of the git repository.  

--- a/reference/artifacts-with-artifactsrewrite/types/git-repo/index.md
+++ b/reference/artifacts-with-artifactsrewrite/types/git-repo/index.md
@@ -15,23 +15,6 @@ by stages that need multiple files to produce an output, such as the Bake (Manif
 renderer. Unlike other artifact implementations, the Git Repo artifact works with any Git hosting service as long as the
 repository can be cloned using the Git CLI.
 
-## Configuration
-
-Configuring `git/repo` artifacts is not currently supported by Halyard.  As such, configuration for this artifact type must be
-performed through a custom Clouddriver profile.
-
-To configure a `git/repo` artifact account, add the following to `~/.hal/default/profiles/clouddriver-local.yml`:
-
-```yaml
-artifacts:
-  gitRepo:
-    enabled: true
-    accounts:
-    - name: gitrepo
-      token: 12344 #github personal access token
-```
-Don't forget to run `hal deploy apply` after making your changes.
-
 ## Git Repo artifact in the UI
 
 The pipeline UI exposes the following fields for the GitHub file artifact:

--- a/reference/artifacts/types/git-repo/index.md
+++ b/reference/artifacts/types/git-repo/index.md
@@ -15,22 +15,6 @@ by stages that need multiple files to produce an output such as the Bake (Manife
 renderer. Unlike other artifact implementation, the Git Repo artifact will work with any Git hosting service as long as the
 repository can be cloned using the Git CLI.
 
-## Configuration
-
-Configuring `git/repo` artifacts is not currently supported by Halyard.  As such, configuration for this artifact type must be
-performed through a custom Clouddriver profile.
-
-To configure a `git/repo` artifact account, add the following to `~/.hal/default/profiles/clouddriver-local.yml`:
-
-```yaml
-artifacts:
-  gitRepo:
-    enabled: true
-    accounts:
-    - name: gitrepo
-      token: 12344 #github personal access token
-```
-Don't forget to run `hal deploy apply` after making your changes.
 
 ## Fields
 

--- a/setup/artifacts/gitrepo.md
+++ b/setup/artifacts/gitrepo.md
@@ -7,7 +7,7 @@ sidebar:
 
 {% include toc %}
 
-This shows how to configure a Git Repo artifact account so Spinnaker can use entire repositories as a single artifact.
+This shows how to configure a Git Repo artifact account so Spinnaker can use an entire repository as a single artifact.
 
 ## Prerequisites
 

--- a/setup/artifacts/gitrepo.md
+++ b/setup/artifacts/gitrepo.md
@@ -1,0 +1,79 @@
+---
+layout: single
+title:  "Configure a Git Repo artifact account"
+sidebar:
+  nav: setup
+---
+
+{% include toc %}
+
+This shows how to configure a Git Repo artifact account so Spinnaker can use entire repositories as a single artifact.
+
+## Prerequisites
+
+* You need a Git account.
+
+
+## Enable Git Repo artifacts
+
+First, enable [artifact support](/reference/artifacts-with-artifactsrewrite//#enabling-artifact-support).
+
+Next, enable the Git Repo artifact provider:
+
+```bash
+hal config artifact gitrepo enable
+```
+
+## Configure Auth
+Choose to set up either token, user-password or ssh key auth below.
+
+### Token Auth
+
+Start by generating an access token for your Git provider (eg, [GitHub](https://github.com/settings/tokens){:target="\_blank"} or [GitLab](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html){:target="\_blank"}). The token requires the __repo__ scope.
+
+Place the token in a file (`$TOKEN_FILE`) readable by Halyard:
+
+```bash
+echo $TOKEN > $TOKEN_FILE
+```
+
+Add an artifact account:
+
+```bash
+hal config artifact gitrepo account add $ARTIFACT_ACCOUNT_NAME \
+    --token-file $TOKEN_FILE
+```
+
+
+### User-Password Auth
+
+The username-password file contents should be in the format:
+
+ ```
+ <username>:<password>
+ ```
+
+Add an artifact account:
+
+```bash
+hal config artifact gitrepo account add $ARTIFACT_ACCOUNT_NAME \
+    ----username-password-file $PASSWORD_FILE
+```
+
+
+### SSH Key Auth
+
+Add an artifact account:
+
+```bash
+hal config artifact gitrepo account add $ARTIFACT_ACCOUNT_NAME \
+    --ssh-private-key-file-path $SSH_KEY_FILE \
+    --ssh-private-key-passphrase \
+    --ssh-known-hosts-file-path $KNOWN_HOSTS_FILE 
+
+```
+
+
+There are more options described
+[here](/reference/halyard/commands#hal-config-artifact-gitrepo-account-edit)
+if you need more control over your configuration.

--- a/setup/artifacts/gitrepo.md
+++ b/setup/artifacts/gitrepo.md
@@ -57,7 +57,7 @@ Choose to set up either token, user-password or ssh key auth below.
 
    ```bash
    hal config artifact gitrepo account add $ARTIFACT_ACCOUNT_NAME \
-    ----username-password-file $PASSWORD_FILE
+    --username-password-file $PASSWORD_FILE
    ```
 
 

--- a/setup/artifacts/gitrepo.md
+++ b/setup/artifacts/gitrepo.md
@@ -41,7 +41,7 @@ Choose to set up either token, user-password or ssh key auth below.
 
    ```bash
    hal config artifact gitrepo account add $ARTIFACT_ACCOUNT_NAME \
-    --token-file $TOKEN_FILE
+       --token-file $TOKEN_FILE
 ```
 
 

--- a/setup/artifacts/gitrepo.md
+++ b/setup/artifacts/gitrepo.md
@@ -40,7 +40,7 @@ Choose to set up either token, user-password or ssh key auth below.
 Add an artifact account:
 
    ```bash
-hal config artifact gitrepo account add $ARTIFACT_ACCOUNT_NAME \
+   hal config artifact gitrepo account add $ARTIFACT_ACCOUNT_NAME \
     --token-file $TOKEN_FILE
 ```
 

--- a/setup/artifacts/gitrepo.md
+++ b/setup/artifacts/gitrepo.md
@@ -39,7 +39,7 @@ echo $TOKEN > $TOKEN_FILE
 
 Add an artifact account:
 
-```bash
+   ```bash
 hal config artifact gitrepo account add $ARTIFACT_ACCOUNT_NAME \
     --token-file $TOKEN_FILE
 ```

--- a/setup/artifacts/gitrepo.md
+++ b/setup/artifacts/gitrepo.md
@@ -31,7 +31,7 @@ Choose to set up either token, user-password or ssh key auth below.
 
 1. Generate an access token for your Git provider (eg, [GitHub](https://github.com/settings/tokens){:target="\_blank"} or [GitLab](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html){:target="\_blank"}). The token requires the __repo__ scope.
 
-Place the token in a file (`$TOKEN_FILE`) readable by Halyard:
+1. Place the token in a file (`$TOKEN_FILE`) readable by Halyard:
 
 ```bash
 echo $TOKEN > $TOKEN_FILE

--- a/setup/artifacts/gitrepo.md
+++ b/setup/artifacts/gitrepo.md
@@ -34,7 +34,7 @@ Choose to set up either token, user-password or ssh key auth below.
 1. Place the token in a file (`$TOKEN_FILE`) readable by Halyard:
 
 ```bash
-echo $TOKEN > $TOKEN_FILE
+   echo $TOKEN > $TOKEN_FILE
 ```
 
 Add an artifact account:

--- a/setup/artifacts/gitrepo.md
+++ b/setup/artifacts/gitrepo.md
@@ -29,7 +29,7 @@ Choose to set up either token, user-password or ssh key auth below.
 
 ### Token Auth
 
-Start by generating an access token for your Git provider (eg, [GitHub](https://github.com/settings/tokens){:target="\_blank"} or [GitLab](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html){:target="\_blank"}). The token requires the __repo__ scope.
+1. Generate an access token for your Git provider (eg, [GitHub](https://github.com/settings/tokens){:target="\_blank"} or [GitLab](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html){:target="\_blank"}). The token requires the __repo__ scope.
 
 Place the token in a file (`$TOKEN_FILE`) readable by Halyard:
 

--- a/setup/artifacts/gitrepo.md
+++ b/setup/artifacts/gitrepo.md
@@ -37,7 +37,7 @@ Choose to set up either token, user-password or ssh key auth below.
    echo $TOKEN > $TOKEN_FILE
 ```
 
-Add an artifact account:
+1. Add an artifact account:
 
    ```bash
    hal config artifact gitrepo account add $ARTIFACT_ACCOUNT_NAME \

--- a/setup/artifacts/gitrepo.md
+++ b/setup/artifacts/gitrepo.md
@@ -47,7 +47,7 @@ hal config artifact gitrepo account add $ARTIFACT_ACCOUNT_NAME \
 
 ### User-Password Auth
 
-The username-password file contents should be in the format:
+1. Create a username-password file, with contents in the following format:
 
  ```
  <username>:<password>

--- a/setup/artifacts/gitrepo.md
+++ b/setup/artifacts/gitrepo.md
@@ -33,7 +33,7 @@ Choose to set up either token, user-password or ssh key auth below.
 
 1. Place the token in a file (`$TOKEN_FILE`) readable by Halyard:
 
-```bash
+   ```bash
    echo $TOKEN > $TOKEN_FILE
 ```
 

--- a/setup/artifacts/gitrepo.md
+++ b/setup/artifacts/gitrepo.md
@@ -35,30 +35,30 @@ Choose to set up either token, user-password or ssh key auth below.
 
    ```bash
    echo $TOKEN > $TOKEN_FILE
-```
+   ```
 
 1. Add an artifact account:
 
    ```bash
    hal config artifact gitrepo account add $ARTIFACT_ACCOUNT_NAME \
        --token-file $TOKEN_FILE
-```
+   ```
 
 
 ### User-Password Auth
 
 1. Create a username-password file, with contents in the following format:
 
- ```
- <username>:<password>
- ```
+   ```
+   <username>:<password>
+   ```
 
-Add an artifact account:
+1. Add an artifact account:
 
-```bash
-hal config artifact gitrepo account add $ARTIFACT_ACCOUNT_NAME \
+   ```bash
+   hal config artifact gitrepo account add $ARTIFACT_ACCOUNT_NAME \
     ----username-password-file $PASSWORD_FILE
-```
+   ```
 
 
 ### SSH Key Auth

--- a/setup/artifacts/index.md
+++ b/setup/artifacts/index.md
@@ -16,6 +16,7 @@ credentials.
 * [Bitbucket](/setup/artifacts/bitbucket/)
 * [GitHub](/setup/artifacts/github/)
 * [GitLab](/setup/artifacts/gitlab/)
+* [Git Repo](/setup/artifacts/gitrepo/)
 * [Google Cloud Storage](/setup/artifacts/gcs/)
 * [HTTP](/setup/artifacts/http/)
 * [Maven](/setup/artifacts/maven/)


### PR DESCRIPTION
Git Repo artifacts are now configurable through Halyard, so this removes the directions for configuring through a `clouddriver-local.yml` and adds directions for using Halyard.