### PR TITLE
Fix Fiat's "Administrator functionality" sample profile 

### DIFF
--- a/setup/security/admin/index.md
+++ b/setup/security/admin/index.md
@@ -25,10 +25,9 @@ TBD
 In the Fiat config file, add the following:
 
 ```yaml
-fiat:
-  admin:
-    roles:
-      - devops-admin
+admin:
+  roles:
+    - devops-admin
 ```
 
 > For installations managed by Halyard, the file should be located in the following path


### PR DESCRIPTION
## What

As title. If we `hal deploy apply` with the sample profile after placing the file in `~/.hal/$DEPLOYMENT/profiles/fiat-local.yml` as the note suggests, it will not work.