### PR TITLE
docs(spincli): update spincli documentation for new features

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -546,6 +546,8 @@ guides:
         url: /guides/spin/pipeline/
       - title: Manage Pipeline Templates
         url: /guides/spin/pipeline-templates/
+      - title: Manage Projects
+        url: /guides/spin/projects/
   - title: Service Overviews
     collapsed: true
     children:

--- a/guides/spin/pipeline/index.md
+++ b/guides/spin/pipeline/index.md
@@ -45,7 +45,7 @@ Use " pipeline [command] --help" for more information about a command.
 ```
 
 The following assumes Spinnaker is running and Gate is
-listening on `http://localhost:8084`. If gate is running elsewhere,
+listening on `http://localhost:8084`. If Gate is running elsewhere,
 you can set the Gate endpoint with the global `--gate-endpoint` flag.
 
 ## Managing your pipeline's lifecycle

--- a/guides/spin/pipeline/index.md
+++ b/guides/spin/pipeline/index.md
@@ -120,10 +120,30 @@ flag or via STDIN, e.g.
 }
 ```
 
+You can pass in paramaters as key-value pairs with the `-p` flag as such:
+
+```bash
+spin pipeline execute --application my-app --name my-pipeline -p foo=bar,baz=qux
+```
+
 ### Delete a pipeline with `delete`
 
 ```bash
 spin pipeline delete --name my-pipeline --application my-app
 
 Pipeline deleted
+```
+
+### Enable/Disable a pipeline with `update`
+
+```bash
+spin pipeline update --application my-app --name my-pipeline --enabled
+
+Pipeline updated
+```
+
+```bash
+spin pipeline update --application my-app --name my-pipeline --disabled
+
+Pipeline updated
 ```

--- a/guides/spin/pipeline/index.md
+++ b/guides/spin/pipeline/index.md
@@ -48,7 +48,7 @@ The following assumes Spinnaker is running and Gate is
 listening on `http://localhost:8084`. If gate is running elsewhere,
 you can set the Gate endpoint with the global `--gate-endpoint` flag.
 
-## Managing Your Pipeline's Lifecycle
+## Managing your pipeline's lifecycle
 
 ### Create and update pipelines with `save`
 
@@ -57,6 +57,7 @@ $ spin pipeline save --file <path to pipeline json>
 
 Parsed submitted pipeline: <...>
 
+# Returns the following message if the pipeline gets updated successfully.
 Pipeline save succeeded
 ```
 
@@ -134,16 +135,18 @@ spin pipeline delete --name my-pipeline --application my-app
 Pipeline deleted
 ```
 
-### Enable/Disable a pipeline with `update`
+### Enable/disable a pipeline with `update`
 
 ```bash
 spin pipeline update --application my-app --name my-pipeline --enabled
 
+# Returns the following message if the pipeline gets updated successfully.
 Pipeline updated
 ```
 
 ```bash
 spin pipeline update --application my-app --name my-pipeline --disabled
 
+# Returns the following message if the pipeline gets updated successfully.
 Pipeline updated
 ```

--- a/guides/spin/projects/index.md
+++ b/guides/spin/projects/index.md
@@ -10,7 +10,7 @@ sidebar:
 ## Overview
 
 Once you have `spin` installed and configured, you can use it to start
-managing your Spinnaker pipelines.
+managing your Spinnaker project dashboards as code.
 
 `spin` can manage the whole lifecycle of your projects:
 
@@ -45,17 +45,15 @@ Use " project [command] --help" for more information about a command.
 ```
 
 The following assumes Spinnaker is running and Gate is
-listening on `http://localhost:8084`. If gate is running elsewhere,
+listening on `http://localhost:8084`. If Gate is running elsewhere,
 you can set the Gate endpoint with the global `--gate-endpoint` flag.
 
-## Managing Your Pipeline's Lifecycle
+## Managing your project's lifecycle
 
-### Create and update pipelines with `save`
+### Create and update projects with `save`
 
 ```bash
 $ spin project save --file <path to project json>
-
-Parsed submitted project: <...>
 
 Project save succeeded
 ```

--- a/guides/spin/projects/index.md
+++ b/guides/spin/projects/index.md
@@ -1,0 +1,122 @@
+---
+layout: single
+title:  "Manage Projects"
+sidebar:
+  nav: guides
+---
+
+{% include toc %}
+
+## Overview
+
+Once you have `spin` installed and configured, you can use it to start
+managing your Spinnaker pipelines.
+
+`spin` can manage the whole lifecycle of your projects:
+
+```bash
+$ spin project
+Usage:
+   project [command]
+
+Aliases:
+  project, prj
+
+Available Commands:
+  delete        Delete the provided project
+  get           Get the config for the specified project
+  get-pipelines Get the pipelines for the specified project
+  list          List the all projects
+  save          Save the provided project
+
+Flags:
+  -h, --help   help for project
+
+Global Flags:
+      --config string            path to config file (default $HOME/.spin/config)
+      --default-headers string   configure default headers for gate client as comma separated list (e.g. key1=value1,key2=value2)
+      --gate-endpoint string     Gate (API server) endpoint (default http://localhost:8084)
+  -k, --insecure                 ignore certificate errors
+      --no-color                 disable color (default true)
+  -o, --output string            configure output formatting
+  -q, --quiet                    squelch non-essential output
+
+Use " project [command] --help" for more information about a command.
+```
+
+The following assumes Spinnaker is running and Gate is
+listening on `http://localhost:8084`. If gate is running elsewhere,
+you can set the Gate endpoint with the global `--gate-endpoint` flag.
+
+## Managing Your Pipeline's Lifecycle
+
+### Create and update pipelines with `save`
+
+```bash
+$ spin project save --file <path to project json>
+
+Parsed submitted project: <...>
+
+Project save succeeded
+```
+
+Note that `save` accepts project in JSON format. You can quickly export an
+existing project into a valid argument to the `--file` flag by using the `get` command.
+
+You can also template the pipeline JSON using your favorite templating engine.
+A demo of creating projects via spinnaker's jsonnet library, sponnet, can be seen here:
+https://github.com/spinnaker/sponnet/tree/master/demo#sponnet-demo
+
+### List projects `list`
+
+```bash
+spin project list
+
+[
+ {
+  "config": {
+   "applications": [...],
+   "clusters": [...],
+   "pipelineConfigs": [...]
+  },
+  ...
+ }
+]
+```
+
+### Retrieve a single project with `get`
+
+Get a single project with `get`:
+
+```bash
+spin project get <project name>
+{
+"config": {
+ "applications": [...],
+ "clusters": [...],
+ "pipelineConfigs": [...]
+  }
+...
+}
+```
+
+### Get a project's pipelines with `get-pipelines`
+
+Get a project's pipelines with `get-pipelines`:
+
+```bash
+spin project get-pipelines <project name>
+
+{
+  "application": "my-app"
+  "stages": [...]
+}
+```
+
+### Delete a project with `delete`
+
+```bash
+spin project delete --name <project name>
+
+Project deleted
+```

--- a/guides/spin/projects/index.md
+++ b/guides/spin/projects/index.md
@@ -34,7 +34,7 @@ Flags:
 
 Global Flags:
       --config string            path to config file (default $HOME/.spin/config)
-      --default-headers string   configure default headers for gate client as comma separated list (e.g. key1=value1,key2=value2)
+      --default-headers string   configure default headers for Gate client as comma separated list (e.g. key1=value1,key2=value2)
       --gate-endpoint string     Gate (API server) endpoint (default http://localhost:8084)
   -k, --insecure                 ignore certificate errors
       --no-color                 disable color (default true)


### PR DESCRIPTION
This documents new features for the spin CLI.

For projects, these features reference:
https://github.com/spinnaker/spin/pull/261
https://github.com/spinnaker/spin/pull/260
https://github.com/spinnaker/spin/pull/258
https://github.com/spinnaker/spin/pull/270

For pipelines, these features reference:
https://github.com/spinnaker/spin/pull/280
https://github.com/spinnaker/spin/pull/278

While these features are in current master, I'm unsure of how coordination with spin cli releases and documentation get coordinated, but thought I'd open the PR since its in master for spin CLI.