### PR TITLE
docs(kubernetes): Update kubernetes v2 provider documentation to state that Spinnaker by default versions ReplicaSets. 

### DIFF
--- a/reference/providers/kubernetes-v2/index.md
+++ b/reference/providers/kubernetes-v2/index.md
@@ -306,7 +306,7 @@ __Clusters__ tab in Spinnaker. If possible, any pods owned by the workload are r
 | __`DaemonSet`__ | Yes | Yes | No | Yes | Yes | Yes | No | The `status.currentNumberScheduled`, `status.updatedNumberScheduled`, `status.numberAvailable`, and `status.numberReady` must all be at least the `status.desiredNumberScheduled`. |
 | __`Deployment`__ | Yes | Yes | Yes | Yes | Yes | Yes | No | The `status.updatedReplicas`, `status.availableReplicas`, and `status.readyReplicas` must all match the desired replica count for the Deployment. |
 | __`Pod`__ | Yes | Yes | No | No | No | No | Yes | The pod must be scheduled, and pass all probes. |
-| __`ReplicaSet`__ | Yes | Yes | Yes | No | No | No | No | The `status.fullyLabledReplicas`, `status.availableReplicas`, and `status.readyReplicas` must all match the desired replica count for the ReplicaSet. |
+| __`ReplicaSet`__ | Yes | Yes | Yes | No | No | No | Yes | The `status.fullyLabledReplicas`, `status.availableReplicas`, and `status.readyReplicas` must all match the desired replica count for the ReplicaSet. |
 | __`StatefulSet`__ | Yes | Yes | Yes | Yes | Yes | Yes | No | The `status.currentRevision`, and `status.updatedRevision` must match, and `status.currentReplicas`, and `status.readyReplicas` must match the spec's replica count. |
 
 ## Services, ingresses


### PR DESCRIPTION
docs(kubernetes): Update kubernetes v2 provider documentation to state that Spinnaker by default versions ReplicaSets. 