### PR TITLE
feat(docs): slim down annotation-driven UI contract

### DIFF
--- a/community/releases/next-release-preview/index.md
+++ b/community/releases/next-release-preview/index.md
@@ -55,3 +55,18 @@ Spinnaker's UI has changed! An application's nested menus are now represented as
 This change should not introduce any interruptions to a vanilla install of `deck`. However, if you've already made navigational changes to your group's instance of `deck` or created custom banners/headers for your app, you may need to make updates. The pattern for creating new routes in the side nav can be observed in the feature's PR:
 
 https://github.com/spinnaker/deck/pull/8239
+
+### Kubernetes Annotation-Driven UI Update
+
+Please see the Kubernetes Annotation-Driven UI
+[documentation](/guides/user/kubernetes-v2/annotations-ui) for the current
+list of available template values for each Spinnaker resource kind. Previously,
+the following template values were available on each kind:
+
+- apiVersion
+- displayName
+- kind
+- namespace
+
+These values should now be read directly from the Kubernetes `manifest`, which
+is available as a top-level key for each resource kind.

--- a/guides/user/kubernetes-v2/annotations-ui/index.md
+++ b/guides/user/kubernetes-v2/annotations-ui/index.md
@@ -76,51 +76,37 @@ for the resource that is annotated.  The complete set of available keys is docum
 #### Instances
 
 - account - the spinnaker account for this resource
-- apiVersion - the kubernetes apiVersion of this resource
 - cloudProvider - this will always be `kubernetes`
-- displayName - the name of the resource prepared for UI display
-- hasHealthStatus - a boolean indicating whether the instance has health status
 - healthState - the instance's health status, if available
 - id - the instance's id
-- kind - the kubernetes kind of this resource
 - manifest - the kubernetes manifest as JSON object
 - name - the resource's name
-- namespace - the kubernetes namespace in which this resource resides
 
 #### Load Balancers
 
 - account - the spinnaker account for this resource
-- apiVersion - the kubernetes apiVersion of this resource
 - cloudProvider - this will always be `kubernetes`
 - detail - the spinnaker detail, if any, for this resource
-- displayName - the name of the resource prepared for UI display
-- kind - the kubernetes kind of this resource
 - manifest - the kubernetes manifest as JSON object
 - name - the resource's name
-- namespace - the kubernetes namespace in which this resource resides
 - stack - the spinnaker stack, if any, for this resource
 - type - this resource's spinnaker type
 
 #### Security Groups
 
 - account - the spinnaker account for this resource
-- apiVersion - the kubernetes apiVersion of this resource
 - application - the spinnaker application name, if any, for this resource
 - cloudProvider - this will always be `kubernetes`
 - detail - the spinnaker detail, if any, for this resource
-- displayName - the name of the resource prepared for UI display
 - id - the security group's id
-- kind - the kubernetes kind of this resource
 - manifest - the kubernetes manifest as JSON object
 - name - the resource's name
-- namespace - the kubernetes namespace in which this resource resides
 - stack - the spinnaker stack, if any, for this resource
 - type - this resource's spinnaker type
 
 #### Server Groups
 
 - account - the spinnaker account for this resource
-- apiVersion - the kubernetes apiVersion of this resource
 - app - the spinnaker application name, if any, for this resource
 - category - the spinnaker category, if any, for this resource
 - cloudProvider - this will always be `kubernetes`
@@ -129,22 +115,14 @@ for the resource that is annotated.  The complete set of available keys is docum
 - detail - the spinnaker detail, if any, for this resource
 - disabled - a boolean that is true if this server group is disabled
 - disabledDate - a number representing the date this server group was disabled
-- displayName - the name of the resource prepared for UI display
-- kind - the kubernetes kind of this resource
 - manifest - the kubernetes manifest as JSON object
 - name - the resource's name
-- namespace - the kubernetes namespace in which this resource resides
-- region - the region this server group is in
 - stack - the spinnaker stack, if any, for this resource
 - type - this resource's spinnaker type
 
 #### Server Group Managers
 
 - account - the spinnaker account for this resource
-- apiVersion - the kubernetes apiVersion of this resource
 - cloudProvider - this will always be `kubernetes`
-- displayName - the name of the resource prepared for UI display
-- kind - the kubernetes kind of this resource
 - manifest - the kubernetes manifest as JSON object
 - name - the resource's name
-- namespace - the kubernetes namespace in which this resource resides


### PR DESCRIPTION
Since we are committing to a contract in which the annotation-driven UI is supplied the full Kubernetes manifest to hydrate template values, let's encourage users to read values readily available there rather than relying on them as top-level keys for each infrastructure type. Specifically, let's remove apiVersion, displayName, kind, and namespace, as these are guaranteed to be available on the manifest, and Deck is currently just reading these from the manifest anyway to populate these fields. Alternately, we could have Clouddriver include these fields rather than having Deck read them directly off the manifest, but since we are trying to minimize Clouddriver's contract with Deck, let's do this instead.

Also removes the Instance type's `hasHealthStatus`, which does not appear to be getting set by Clouddriver anyway.