### PR TITLE
feat(release-runbook): add details on how far to backport a fix

### DIFF
--- a/community/releases/release-manager-runbook/index.md
+++ b/community/releases/release-manager-runbook/index.md
@@ -426,13 +426,15 @@ Repeat weekly.
 [release branch patch criteria](/community/contributing/releasing#release-branch-patch-criteria):
 
     1. Remove the `backport-candidate` label from the PR.
+
+    1. Determine which versions the PR needs to be backported to. If it gets backported to an older version, all new versions should get the backport as well. Go only as far back as the supported [stable versions](https://spinnaker.io/community/releases/versions/#latest-stable).
     
     1. Add a comment instructing
        [Mergify](https://doc.mergify.io/commands.html#backport) to create
        backport PRs against one or more release branches. For example, to
-       create backport PRs against the 1.20 and 1.21 release branches, comment:
+       create backport PRs against the 1.19, 1.20 and 1.21 release branches, comment:
        
-       > @Mergifyio backport release-1.20.x release-1.21.x
+       > @Mergifyio backport release-1.19.x release-1.20.x release-1.21.x
 
     1. Approve and merge the backport PRs.
 


### PR DESCRIPTION
If the current unreleased version is 1.22 and a backport candidate will fix 1.19, make PRs to 1.20, and 1.21 as well.