### PR TITLE
docs(plugins): state 1.21+ support

### DIFF
--- a/guides/user/plugins/deploy-example.md
+++ b/guides/user/plugins/deploy-example.md
@@ -6,7 +6,7 @@ sidebar:
   nav: guides
 ---
 
-{% include alpha version="1.20.6" %}
+_Note: Spinnaker 1.20.6 and 1.21+ support plugins with both server and frontend components. Spinnaker 1.19.x does not support frontend plugins due to a bug in Deck._
 
 {% include toc %}
 
@@ -18,7 +18,7 @@ In this guide, you deploy the `pf4jStagePlugin` plugin from the [spinnaker-plugi
 
 This guide was tested with the following software versions:
 
-* Spinnaker 1.20.6 and 1.21.0
+* Spinnaker 1.20.6 and 1.21+
 * Halyard 1.36
 * pf4jStagePlugin 1.1.14
 

--- a/guides/user/plugins/index.md
+++ b/guides/user/plugins/index.md
@@ -8,9 +8,7 @@ redirect_from:
   - /guides/user/plugins/user-guide/
 ---
 
-{% include alpha version="1.20.6" %}
-
-_Note: Spinnaker 1.19.x does not support frontend plugins due to a bug in Deck._
+_Note: Spinnaker 1.20.6 and 1.21+ support plugins with both server and frontend components. Spinnaker 1.19.x does not support frontend plugins due to a bug in Deck._
 
 {% include toc %}
 
@@ -41,8 +39,8 @@ Spinnaker uses [PF4J-Update](https://github.com/pf4j/pf4j-update) to load and ma
 
 Spinnaker environment:
 
-* Spinnaker v1.20.6, v1.21.0 (assumption is v1.21.x but not validated)
-* Halyard v1.36 to deploy Spinnaker (assumption is v1.36+ but not validated)
+* Spinnaker v1.20.6, v1.21+
+* Halyard v1.36 to deploy Spinnaker
 
 
 ## How to add a plugin to Spinnaker


### PR DESCRIPTION
Remove 1.20.6 alpha warning from user guide and deployment example; replace with note about supported versions.