### PR TITLE
docs(clouddriver/sql): Reverting release note info for Clouddriver SQL cache issue since the fix had to be reverted and won't be released in 1.22. 

### DIFF
--- a/community/releases/next-release-preview/index.md
+++ b/community/releases/next-release-preview/index.md
@@ -64,19 +64,3 @@ Spinnaker's UI has changed! An application's nested menus are now represented as
 This change should not introduce any interruptions to a vanilla install of `deck`. However, if you've already made navigational changes to your group's instance of `deck` or created custom banners/headers for your app, you may need to make updates. The pattern for creating new routes in the side nav can be observed in the feature's PR:
 
 https://github.com/spinnaker/deck/pull/8239
-
-### Issue Resolved: Clouddriver SQL Cache Data Too Long
-
-We've fixed an issue that prevented data from being stored in Clouddriver's SQL 
-Cache because the data was too long 
-([Github issue](https://github.com/spinnaker/spinnaker/issues/5600)). As a part
-of this fix we introduced a second version of the tables used by Clouddriver
-for caching. You should see tables named `cats_v2_*` in your Clouddriver 
-database moving forward.
-
-Once you're comfortable with the Spinnaker release and don't expect to roll back 
-to a previous version, then you can delete the first version of the tables used 
-for caching. In order to easily facilitate deleting these tables we have exposed 
-an admin endpoint that will handle the deletion process. The admin endpoint can 
-be reached via a `curl PUT` request against 
-`{your_clouddriver}/admin/db/drop_version/V1`.


### PR DESCRIPTION
* docs(clouddriver/sql): Reverting release note info for Clouddriver SQL cache issue since the fix had to be reverted and won't be released in 1.22. 

  Revert "docs(clouddriver/sql): Add release notes for fix to clouddriver sql cache.  (#2001)"

  This reverts commit 4a743465228f121db582e3e45a7a19bb2a7d71ef.