### PR TITLE
docs(incomplete spin nav): update spin navigation to include missing links

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -550,6 +550,8 @@ guides:
         url: /guides/spin/pipeline-templates/
       - title: Manage Projects
         url: /guides/spin/projects/
+      - title: Manage Canary Configs
+        url: /guides/spin/canary-configs/
   - title: Service Overviews
     collapsed: true
     children:

--- a/guides/spin/index.md
+++ b/guides/spin/index.md
@@ -5,11 +5,12 @@ sidebar:
   nav: guides
 ---
 
-This is the guide for the `spin` command-line interface. 
+This is the guide for the `spin` command-line interface.
 
 Before you begin, see [Install and Configure Spin CLI](/setup/spin/).
 
 * [Manage Applications](/guides/spin/app/)
 * [Manage Pipelines](/guides/spin/pipeline/)
 * [Manage Pipeline Templates](/guides/spin/pipeline-templates/)
+* [Manage Projects](/guides/spin/projects/)
 * [Manage Canary Configs](/guides/spin/canary-configs/)


### PR DESCRIPTION
I noticed these links were missing for the spin cli guide and have included them.