### PR TITLE
chore(contributors): Avoid Map<S, O> usage

### DIFF
--- a/community/contributing/back-end-code.md
+++ b/community/contributing/back-end-code.md
@@ -111,7 +111,9 @@ Do not annotate code as deprecated without additional context. Deprecations with
 
 ## Ambiguous Types
 
-Refrain from using open-ended, ambiguous types, such as `Map<String, Object>`. These types, while flexible, make APIs unobvious, difficult to integrate with and test. Instead, use well-defined types, or if a `Map` type is truly needed, use the most constrictive contract as possible, such as `Map<String, String>`.
+Refrain from using open-ended, ambiguous types, such as `Map<String, Object>`. 
+These types, while flexible, make APIs unobvious, difficult to integrate with and test.
+Instead, use well-defined types, or if a `Map` type is truly needed, use the most constrictive contract as possible, such as `Map<String, String>`.
 
 ## Testing
 

--- a/community/contributing/back-end-code.md
+++ b/community/contributing/back-end-code.md
@@ -109,6 +109,10 @@ When deprecating code, you MUST include the `@Deprecation` annotation, _along wi
 
 Do not annotate code as deprecated without additional context. Deprecations without sufficient context will be rejected.
 
+## Ambiguous Types
+
+Refrain from using open-ended, ambiguous types, such as `Map<String, Object>`. These types, while flexible, make APIs unobvious, difficult to integrate with and test. Instead, use well-defined types, or if a `Map` type is truly needed, use the most constrictive contract as possible, such as `Map<String, String>`.
+
 ## Testing
 
 We really appreciate contributions that include tests.


### PR DESCRIPTION
I'm writing an errorprone check for `Map<String, Object>` usage, and I want a place that I can link to from the custom check.