### PR TITLE
docs(clouddriver/kubernetes): Add release notes for Kubernetes manifest image artifact overwriting

### DIFF
--- a/community/releases/next-release-preview/index.md
+++ b/community/releases/next-release-preview/index.md
@@ -12,3 +12,11 @@ in the next release of Spinnaker. These notes will be prepended to the release
 changelog.
 
 ## Coming Soon in Release 1.23
+
+### (Breaking Change) Spinnaker Kubernetes manifest image overwriting with a bound artifact
+
+Spinnaker will now overwrite images in a manifest with a bound artifact if the
+input manifest's image has a tag on it. The previous behavior was that Spinnaker
+would only overwrite images in a manifest if the image did not have a tag.
+
+https://github.com/spinnaker/spinnaker/issues/5948


### PR DESCRIPTION
* docs(clouddriver/kubernetes): Add release notes for Kubernetes manifest image artifact overwriting. 

  Release notes for breaking change discussed in https://github.com/spinnaker/spinnaker/issues/5948. Spinnaker will now overwrite manifest images with a bound artifact even if there is a tag present.