### PR TITLE
feat(docs): tidying up of artifacts docs

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -346,7 +346,24 @@ guides:
             url: /guides/user/pipeline/
           - title: Managing Pipelines
             url: /guides/user/pipeline/managing-pipelines/
-          - title: Triggering Pipelines (Standard Artifacts UI)
+          - title: Triggering Pipelines
+            collapsed: true
+            children:
+            - title: Overview
+              url: /guides/user/pipeline/triggers-with-artifactsrewrite/
+            - title: Triggering pipelines with Jenkins
+              url: /guides/user/pipeline/triggers-with-artifactsrewrite/jenkins/
+            - title: Triggering on Pub/Sub Messages
+              url: /guides/user/pipeline/triggers-with-artifactsrewrite/pubsub/
+            - title: Triggering on Webhooks
+              url: /guides/user/pipeline/triggers-with-artifactsrewrite/webhooks/
+            - title: Receiving Artifacts From GCS
+              url: /guides/user/pipeline/triggers-with-artifactsrewrite/gcs/
+            - title: Receiving Artifacts From GitHub
+              url: /guides/user/pipeline/triggers-with-artifactsrewrite/github/
+            - title: Triggering pipelines with Artifactory
+              url: /guides/user/pipeline/triggers-with-artifactsrewrite/artifactory/
+          - title: Triggering Pipelines (Legacy Artifacts UI)
             collapsed: true
             children:
               - title: Overview
@@ -361,23 +378,6 @@ guides:
                 url: /guides/user/pipeline/triggers/gcs/
               - title: Receiving Artifacts From GitHub
                 url: /guides/user/pipeline/triggers/github/
-          - title: Triggering Pipelines (New Artifacts UI)
-            collapsed: true
-            children:
-              - title: Overview
-                url: /guides/user/pipeline/triggers-with-artifactsrewrite/
-              - title: Triggering pipelines with Jenkins
-                url: /guides/user/pipeline/triggers-with-artifactsrewrite/jenkins/
-              - title: Triggering on Pub/Sub Messages
-                url: /guides/user/pipeline/triggers-with-artifactsrewrite/pubsub/
-              - title: Triggering on Webhooks
-                url: /guides/user/pipeline/triggers-with-artifactsrewrite/webhooks/
-              - title: Receiving Artifacts From GCS
-                url: /guides/user/pipeline/triggers-with-artifactsrewrite/gcs/
-              - title: Receiving Artifacts From GitHub
-                url: /guides/user/pipeline/triggers-with-artifactsrewrite/github/
-              - title: Triggering pipelines with Artifactory
-                url: /guides/user/pipeline/triggers-with-artifactsrewrite/artifactory/
           - title: Pipeline Expressions
             url: /guides/user/pipeline/expressions/
           - title: Searching for Triggered Pipeline Executions

--- a/guides/user/pipeline/triggers/index.md
+++ b/guides/user/pipeline/triggers/index.md
@@ -7,6 +7,11 @@ sidebar:
 
 {% include toc %}
 
+> This section describes configuring pipeline triggers with the legacy artifacts
+> UI, which was removed in release 1.21. Please refer to the
+> [guide](/guides/user/pipeline/triggers-with-artifactsrewrite/) for configuring
+> pipeline triggers with the standard artifacts UI instead.
+
 A pipeline trigger defines when to automatically run a pipeline. There are many
 types of triggers available: Jenkins jobs, webhooks, CRON jobs, even other
 pipelines. Adding a trigger to your pipeline means that the pipeline runs each

--- a/reference/artifacts/index.md
+++ b/reference/artifacts/index.md
@@ -5,7 +5,7 @@ sidebar:
   nav: reference
 ---
 
-> This section refers to the legacy artifacts UI, which is scheduled for removal
+> This section refers to the legacy artifacts UI, which was removed
 > in release 1.21. Please refer to the [standard artifacts guide](/reference/artifacts-with-artifactsrewrite)
 > instead.
 

--- a/reference/providers/kubernetes.md
+++ b/reference/providers/kubernetes.md
@@ -6,7 +6,7 @@ sidebar:
 redirect_from: /reference/providers/kubernetes-v1/
 ---
 
-> ⚠️ Spinnaker's legacy Kubernetes provider (V1) is [scheduled for removal](https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md) in Spinnaker 1.21.
+> ⚠️ Spinnaker's legacy Kubernetes provider (V1) was [removed](https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md) in Spinnaker 1.21.
 > We recommend using the [standard provider (V2)](/reference/providers/kubernetes-v2) instead. 
 
 {% include toc %}

--- a/setup/install/providers/kubernetes-v2/index.md
+++ b/setup/install/providers/kubernetes-v2/index.md
@@ -10,7 +10,7 @@ sidebar:
 
 Spinnaker's Kubernetes provider fully supports Kubernetes-native, manifest-based deployments and is the recommended provider for deploying to Kubernetes with Spinnaker.
 [Spinnaker's legacy Kubernetes provider](https://www.spinnaker.io/setup/install/providers/kubernetes/){:target="\_blank"}
-is [scheduled for removal](https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md){:target="\_blank"} in Spinnaker 1.21.
+was [removed](https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md){:target="\_blank"} in Spinnaker 1.21.
 
 ## Accounts
 

--- a/setup/install/providers/kubernetes.md
+++ b/setup/install/providers/kubernetes.md
@@ -8,7 +8,7 @@ redirect_from:
  - /setup/install/providers/kubernetes-v1/
 ---
 
-> ⚠️ Spinnaker's legacy Kubernetes provider (V1) is [scheduled for removal](https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md) in Spinnaker 1.21.
+> ⚠️ Spinnaker's legacy Kubernetes provider (V1) was [removed](https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md) in Spinnaker 1.21.
 > We recommend using the [standard provider (V2)](/setup/install/providers/kubernetes-v2) instead. 
 
 {% include toc %}


### PR DESCRIPTION
* feat(docs): re-order Triggering Pipelines sections 

  The new artifacts UI is now the default. Re-arrange navigation sections so Triggering Pipelines with new UI comes first, and change language for old UI from "Standard" to "Legacy" for consistency with elsewhere in the documentation.

* feat(docs): redirect from pipeline triggers documentation that refers to the legacy artifacts UI 

* feat(docs): change "scheduled for removal" to "removed" because the past is in the past 
