### PR TITLE
Fix set tx_isolation command

### DIFF
--- a/setup/productionize/persistence/orca-sql.md
+++ b/setup/productionize/persistence/orca-sql.md
@@ -31,7 +31,7 @@ Before deploying Orca, the schema and database uses must first be manually setup
 
 From the MySQL Server command line run
 ```
-set tx_isolation = 'REPEATABLE-READ';
+set tx_isolation = 'READ-COMMITTED';
 ```
 
 2. Setup the schema and database users


### PR DESCRIPTION
The command line setting the tx_isolation variable seems to be incorrect. The value being set in the command line was 'REPEATABLE-READ', while all other references in the documentation lead me to believe it should be 'READ-COMMITTED'.

In my experience, I had several stability issues with Orca using a MySQL instance on Google Cloud SQL, and the problem was at least partially resolved by updating tx_isolation from 'REPEATABLE-READ' to 'READ-COMMITTED'.