### PR TITLE
docs(community): Update conference ad banner

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,8 +1,8 @@
 ---
 layout: home
 conference_ad_row:
-  title: Submit Your Talk for Spinnaker Summit 2020
-  excerpt: "[Submit your proposal now](https://linuxfoundation.smapply.io/prog/spinnaker_summit_2020/) to lead a session at Spinnaker Summit October 19-November 12. We're seeking content on technology topics from across the SDLC, including talks, discussions, workshops, informal fireside interviews, product demos, and more. Be creative! Bonus: a Summit Gardening Days hackathon with free compute will be running all month long! [Learn more](https://www.spinnakersummit.com)."
+  title: Register for Spinnaker Summit 2020
+  excerpt: "[Register today](https://events.linuxfoundation.org/spinnaker-summit/register/) to join us at Spinnaker Summit October 19-November 12. Get access to a month of great talks with your free conference pass and hands on content with your premium ticket. Bonus: a [Summit Gardening Days hackathon](https://events.linuxfoundation.org/spinnaker-summit/program/summit-gardening-days/) with free AWS compute will be running all month long! [Learn more](https://www.spinnakersummit.com)."
   image_path: assets/images/summit-socialmedia-transparent.png
   alt: "Spinnaker Summit Logo"
 slack_row:


### PR DESCRIPTION
I replaced the copy in the `conference_ad_row` to remove the reference to the CFP and add the link to registration and the hackathon. We also changed the call to action from "Submit your proposal now" to "Register today."

The change was needed because the CFP is now closed.