### PR TITLE
Updating deprecated SQL connection pool property

### DIFF
--- a/setup/productionize/persistence/orca-sql.md
+++ b/setup/productionize/persistence/orca-sql.md
@@ -60,14 +60,17 @@ This configuration is your baseline for Orca to talk to SQL, in `orca.yml`.
 ```yaml
 sql:
   enabled: true
-  connectionPool:
-    jdbcUrl: jdbc:mysql://localhost:3306/orca
-    user: orca_service
-    password: hunter2
-    connectionTimeout: 5000
-    maxLifetime: 30000
-    # MariaDB-specific:
-    maxPoolSize: 50
+  connectionPools:
+    default:
+      default: true
+      # additional connection pool parameters are available here,
+      # for more detail and to view defaults, see:
+      # https://github.com/spinnaker/kork/blob/master/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/ConnectionPoolProperties.kt
+      jdbcUrl: jdbc:mysql://localhost:3306/orca
+      user: orca_service
+      password: hunter2
+      # MariaDB-specific:
+      maxPoolSize: 50
   migration:
     jdbcUrl: jdbc:mysql://localhost:3306/orca
     user: orca_migrate


### PR DESCRIPTION
After enabling DEBUG logging on orca, I discovered some of my SQL Connection pool properties were not being applied because sql.connectionPool has been deprecated in favor of sql.connectionPools, and some pool properties have changed names. The most misleading example in the current version is the maxLifetime property, which took me some days to realize was not having any effect, because it has been changed to maxLifetimeMs.

In order to more easily lead people to the latest reference, I changed the configuration example to be more in line with the ones I found for Front50 and CloudDriver, linking to the properties in kork-sql.