### PR TITLE
docs(community): Remove outdated schedule from gardening/schedule 

### DIFF
--- a/community/gardening/schedule.md
+++ b/community/gardening/schedule.md
@@ -1,13 +1,11 @@
 ---
 layout: single
+title: "Schedule"
 sidebar:
   nav: community
 ---
-## Schedule
 The complete Summit Gardening Days schedule of events, in your time zone, is available on the [schedule page](https://events.linuxfoundation.org/spinnaker-summit/program/schedule/) of the Linux Foundation's Spinnaker Summit Website.
 
 You will also find planned Gardening events and standups listed in the [schedule area of the gardening repository](https://github.com/spinnaker-hackathon/gardening/blob/master/schedule.md). [Follow us on Twitter](https://twitter.com/spinnakerio) or join the [#gardening-general](https://spinnakerteam.slack.com/archives/CV4A90DPF) channel for reminders. Stay tuned for schedule additions.
 
 __Anyone is welcome to host an activity__ for 15 minutes or more, and contributors will receive points for hosting activities. All times and topics that adhere to our guidelines are welcome! Please post in [#gardening-general](https://spinnakerteam.slack.com/archives/CV4A90DPF) and mention @gardening-admin to be added to the schedule.
-
-<a id="sched-embed" href="//sgdays.sched.com/">View the Spinnaker Gardening Days V2: Summer 2020 schedule &amp; directory.</a><script type="text/javascript" src="//sgdays.sched.com/js/embed.js"></script>


### PR DESCRIPTION
I removed the sched.com embed from the last gardening days event because that information is now outdated. This change is made in response to a suggestion by @brian-armory