### PR TITLE
docs(halyard): add Java requirement for halyard

### DIFF
--- a/setup/install/halyard.md
+++ b/setup/install/halyard.md
@@ -42,7 +42,7 @@ Halyard runs on...
 
 Prerequisite:
 
-* Halyard requires Java to be installed
+* Halyard requires Java 11 to be installed
 
 1. Get the latest version of Halyard:
 

--- a/setup/install/halyard.md
+++ b/setup/install/halyard.md
@@ -40,6 +40,10 @@ Halyard runs on...
 * Debian 8 or 9
 * macOS (tested on 10.13 High Sierra only)
 
+Prerequisite:
+
+* Halyard requires Java to be installed
+
 1. Get the latest version of Halyard:
 
    For Debian/Ubuntu:


### PR DESCRIPTION
Adding requirement (unclear which version though).

Installing halyard fails if you do not have Java installed which is more common with modern VMs (etc. Ubuntu 20.04 - AWS).