### PR TITLE
Add `deployments/scale` resource to Kubernetes ClusterRole

### DIFF
--- a/setup/install/providers/kubernetes-v2/index.md
+++ b/setup/install/providers/kubernetes-v2/index.md
@@ -120,7 +120,7 @@ rules:
   resources: ["controllerrevisions", "statefulsets"]
   verbs: ["list"]
 - apiGroups: ["extensions", "apps"]
-  resources: ["deployments", "replicasets", "ingresses"]
+  resources: ["deployments", "deployments/scale", "replicasets", "ingresses"]
   verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
 # These permissions are necessary for halyard to operate. We use this role also to deploy Spinnaker itself.
 - apiGroups: [""]


### PR DESCRIPTION
Looks like we also need to have `deployments/scale` resource in Spinnaker role.

```
User "system:serviceaccount:credential:spinnaker" cannot patch resource "deployments/scale" in API group "extensions" in the namespace "default"
```