### PR TITLE
docs(nav): Update navigation; remove obsolete link

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -307,8 +307,6 @@ guides:
             url: /guides/tutorials/codelabs/oci-source-to-prod/
           - title: Continuous Delivery to Kubernetes on Oracle
             url: /guides/tutorials/codelabs/oracle-kubernetes-source-to-prod/
-          - title: Continuous Delivery with Containers on GCP
-            url: /guides/tutorials/codelabs/gcp-kubernetes-source-to-prod/
           - title: Continuous Delivery to Kubernetes on Azure
             url: /guides/tutorials/codelabs/azure-kubernetes-source-to-prod/
           - title: Continuous Delivery to Azure VM Scale Set


### PR DESCRIPTION
Broken link to an old codelab for the k8s v1 provider