### PR TITLE
doc(changelog): Add Amazon ECS callouts to 1.24.x log

### DIFF
--- a/community/releases/next-release-preview/index.md
+++ b/community/releases/next-release-preview/index.md
@@ -44,7 +44,7 @@ aws ecs put-cluster-capacity-providers \
      --region $AWS_REGION
 ```
 
-**NOTE**: If a `capacityProviderStrategy` is specified, the `launchType` parameter must be omitted. 
+**NOTE**: If a `capacityProviderStrategy` is specified, the `launchType` parameter must be omitted. This means that in case of downgrading Spinnaker from 1.24 to a previous version, server groups which may have used capacity provider strategy will need to be updated to again specify the correct launch type.
 
 ### Moniker support for Amazon ECS
 

--- a/community/releases/next-release-preview/index.md
+++ b/community/releases/next-release-preview/index.md
@@ -64,3 +64,7 @@ ecs:
 **NOTES**: 
   * To use ECS service tags, your Amazon ECS account must be opted into using the _long Amazon Resource Name (ARN)_ format. See [AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids) for details.
   * This feature adds validation which requires deploy stage `moniker` values for `app`, `stack`, and `detail` to match top-level `application`, `stack`, and `freeFormDetails` values _if both are present_. Existing pipelines which contain both with different values will need to remove one set or update them to match. 
+
+### Amazon ECS Task Definition caching improvements
+
+Starting in 1.24, the Amazon ECS provider will only cache task definitions associated with Amazon ECS services. Previously, every "active" task definition in the account would be cached, regardless of association with a service. This change does not entail any user-facing changes, but operators may notice a smaller cache footprint and fewer API calls to Amazon ECS. 

--- a/community/releases/next-release-preview/index.md
+++ b/community/releases/next-release-preview/index.md
@@ -31,3 +31,36 @@ available in the old location, and the old location will be disabled in 2021.
 The Bake (manifest) stage now accepts git/repo artifacts when baking a helm
 chart.  See [this issue](https://github.com/spinnaker/spinnaker/issues/5249) for
 background.
+
+### Capacity Provider Strategy support for Amazon ECS
+
+The Amazon ECS provider now supports using a [capacity provider strategy](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-capacity-providers.html) to deploy your ECS service. 
+
+If the selected ECS cluster has one or more capacity providers configured, users can provide a list of strategies leveraging those capacity providers to use for their ECS service deployment. In order to add the built-in `FARGATE` and `FARGATE_SPOT` capacity providers to an existing cluster, run the following:
+```
+aws ecs put-cluster-capacity-providers \
+     --cluster $MY_CLUSTER \
+     --capacity-providers FARGATE FARGATE_SPOT \
+     --region $AWS_REGION
+```
+
+**NOTE**: If a `capacityProviderStrategy` is specified, the `launchType` parameter must be omitted. 
+
+### Moniker support for Amazon ECS
+
+The Amazon ECS provider now supports a [tag-based](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-using-tags.html) Moniker naming strategy for server groups. Users can opt-in to the use of monikers at the ECS provider level or on a per-account basis by specifying the "tags" naming strategey in their hal config:
+
+```
+ecs:
+  enabled: true
+  defaultNamingStrategy: "default"   <--- 'default' naming used by default (field absent) or if specified
+  accounts:
+    - name: "ecs-moniker-acct"
+      awsAccount: "ec2-aws-acct"
+      namingStrategy: "tags"         <--- 'tags' specified for specific account
+
+``` 
+
+**NOTES**: 
+  * To use ECS service tags, your Amazon ECS account must be opted into using the _long Amazon Resource Name (ARN)_ format. See [AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids) for details.
+  * This feature adds validation which requires deploy stage `moniker` values for `app`, `stack`, and `detail` to match top-level `application`, `stack`, and `freeFormDetails` values _if both are present_. Existing pipelines which contain both with different values will need to remove one set or update them to match. 

--- a/community/releases/next-release-preview/index.md
+++ b/community/releases/next-release-preview/index.md
@@ -62,6 +62,7 @@ ecs:
 ``` 
 
 **NOTES**: 
+  * Your AWS `SpinnakerManaged` role will now need to call [`ecs:ListAccountSettings`](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ListAccountSettings.html) in order to validate whether your account is compatible with tags.
   * To use ECS service tags, your Amazon ECS account must be opted into using the _long Amazon Resource Name (ARN)_ format. See [AWS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids) for details.
   * This feature adds validation which requires deploy stage `moniker` values for `app`, `stack`, and `detail` to match top-level `application`, `stack`, and `freeFormDetails` values _if both are present_. Existing pipelines which contain both with different values will need to remove one set or update them to match. 
 


### PR DESCRIPTION
related PRs:

* (cap provider strat) https://github.com/spinnaker/clouddriver/pull/5123
* (cap provider strat) https://github.com/spinnaker/deck/pull/8767
* (moniker) https://github.com/spinnaker/clouddriver/pull/4936
* (task def cache change) https://github.com/spinnaker/clouddriver/pull/5124

### testing

Screenshot:
![image](https://user-images.githubusercontent.com/34254888/101941279-9a9f4c00-3b9c-11eb-88c9-11fc15413155.png)

