### PR TITLE
fix(docs): Fix left-overs from MD updates

### DIFF
--- a/concepts/index.md
+++ b/concepts/index.md
@@ -143,6 +143,4 @@ or the talk below from Spinnaker Summit 2019.
 
 <iframe src="https://www.youtube.com/embed/mEgvOfmLnlY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-> info ""
-> _To get started with Managed Delivery, head on over to the [user guide](/guides/user/managed-delivery/)._
-
+> :bulb: _To get started with Managed Delivery, head on over to the [user guide](/guides/user/managed-delivery/)._

--- a/guides/user/managed-delivery/getting-started/index.md
+++ b/guides/user/managed-delivery/getting-started/index.md
@@ -8,10 +8,7 @@ redirect_from: /reference/managed-delivery/getting-started/
 
 {% include toc %}
 
-Managed Delivery is currently in Alpha. 
-This means that we support only EC2 and Titus, and that we have limited feature and UI support.
 This guide walks through onboarding to Managed Delivery assuming that you are using EC2 or Titus.
-
 
 ## Intro
 


### PR DESCRIPTION
Turns out that GitHub Pages only supports [a subset of Jekyll plugins](https://pages.github.com/versions/), and `premonition` is not on the list. Also removing a reference to MD being Alpha that I missed in #2117.