### PR TITLE
chore(telemetry): broken link: LF's telemetry policy doc has moved

### DIFF
--- a/community/stats/index.md
+++ b/community/stats/index.md
@@ -35,7 +35,7 @@ Spinnaker's telemetry module collects the following bits of data:
     * Type
     * Cloud Provider
 
-Spinnaker's telemetry project has been reviewed and approved as compliant with the [Linux Foundation's Telemetry Data Collection and Usage Policy](https://www.linuxfoundation.org/telemetry-data-policy/#completed).
+Spinnaker's telemetry project has been reviewed and approved as compliant with the [Linux Foundation's Telemetry Data Collection and Usage Policy](https://www.linuxfoundation.org/telemetry-data-collection-and-usage-policy/).
 
 ## How is the data collected?
 


### PR DESCRIPTION
This is a simple url update to shift to the current location of the
Linux Foundation's telemetry data collection and usage policy.

Signed-off-by: Tim Pepper <tpepper@vmware.com>