### PR TITLE
Update stageByRefId description

### DIFF
--- a/reference/pipeline/expressions/index.md
+++ b/reference/pipeline/expressions/index.md
@@ -204,7 +204,7 @@ access a property via `${#stage("Bake")["context"]["desiredProperty"]}`.
 
 ### #stageByRefId(String)
 
-A shortcut to get the stage by its `refId`. For example, `${#stage("3")}` allows
+A shortcut to get the stage by its `refId`. For example, `${#stageByRefId("3")}` allows
 you to access the stage with `refId = 3`.
 
 ### #currentStage()


### PR DESCRIPTION
The description of the stageByRefId helper function has an example that uses #stage() instead of #stageByRefId()