### PR TITLE
docs(fix): move links to outdated content

### DIFF
--- a/setup/quickstart/index.md
+++ b/setup/quickstart/index.md
@@ -5,14 +5,24 @@ sidebar:
   nav: setup
 ---
 
-Here are some options for installing Spinnaker in cloud environments or Kubernetes.
-
-* [Amazon Web Services](https://aws.amazon.com/about-aws/whats-new/2016/08/netflix-oss-spinnaker-on-the-aws-cloud-quick-start-reference-deployment/) 2016
-* [Spinnaker for Google Cloud Platform](https://cloud.google.com/docs/ci-cd/spinnaker/spinnaker-for-gcp) 2020
-* [Microsoft Azure](https://azure.microsoft.com/en-us/resources/templates/301-jenkins-acr-spinnaker-k8s/)
-* [Kubernetes Helm Chart](https://github.com/kubernetes/charts/tree/master/stable/spinnaker) **As of Nov 13, 2020, charts in this repo are no longer updated. **
-* [Spinnaker Operator](https://operatorhub.io/operator/spinnaker-operator) is an open source Helm chart for installing Spinnaker.
-* [Spinnaker Operator for Kubernetes](https://github.com/armory/spinnaker-operator) is an open source Kubernetes Operator for deploying and managing Spinnaker. You can install a basic version of Spinnaker or use Kustomize files for advanced configuration.
-
-
 If you want to install Spinnaker on Lightweight Kubernetes (K3s) for proofs of concept, see the open source project [Minnaker](https://github.com/armory/minnaker). You can install Spinnaker in about 10 minutes in a local or cloud VM.
+
+Options for installing Spinnaker in Kubernetes:
+
+* [Spinnaker Operator for Kubernetes](https://github.com/armory/spinnaker-operator) is an open source Kubernetes Operator for deploying and managing Spinnaker. You can install a basic version of Spinnaker or use Kustomize files for advanced configuration.
+* [Spinnaker Operator](https://operatorhub.io/operator/spinnaker-operator) is an open source Helm chart for installing Spinnaker.
+* [Kubernetes Helm Chart](https://github.com/kubernetes/charts/tree/master/stable/spinnaker) **As of Nov 13, 2020, charts in this repo are no longer updated. **
+
+Guides for installing Spinnaker in specific cloud environments:
+
+>These guides may contain outdated content.
+
+* [Spinnaker for Google Cloud Platform](https://cloud.google.com/docs/ci-cd/spinnaker/spinnaker-for-gcp) 2020
+* [Microsoft Azure](https://azure.microsoft.com/en-us/resources/templates/301-jenkins-acr-spinnaker-k8s/) 2018
+* [Amazon Web Services](https://aws.amazon.com/about-aws/whats-new/2016/08/netflix-oss-spinnaker-on-the-aws-cloud-quick-start-reference-deployment/) 2016
+
+
+
+
+
+


### PR DESCRIPTION
Fixes: #2146 
Move links to outdated content to the bottom of list.