### PR TITLE
docs(plugins): add link to Spinnaker Operator repo docs

### DIFF
--- a/_includes/plugins-spin-operator.md
+++ b/_includes/plugins-spin-operator.md
@@ -1,0 +1,1 @@
+>Note: If you use the open source [Spinnaker Operator](https://github.com/armory/spinnaker-operator) to install and manage Spinnaker, see that product's [documentation](https://github.com/armory/spinnaker-operator/blob/master/README.md#install-spinnaker-plugins) for how to deploy a plugin.

--- a/guides/developer/plugins/frontend.md
+++ b/guides/developer/plugins/frontend.md
@@ -329,7 +329,7 @@ profiles:
 
 * [Test your plugin locally using Minnaker]({% link guides/developer/plugins/testing/deck-plugin.md %})
 * [Plugin Compatibility Testing]({% link guides/developer/plugins/testing/compatibility-testing.md %})
-* [Deploy your plugin]({% link guides/user/plugins/index.md %})
+* [Deploy your plugin using Halyard]({% link guides/user/plugins/index.md %})
 
-
+{% include plugins-spin-operator.md %}
 

--- a/guides/user/plugins/deploy-example.md
+++ b/guides/user/plugins/deploy-example.md
@@ -24,6 +24,8 @@ This guide was tested with the following software versions:
 * Halyard 1.36+
 * pf4jStagePlugin 1.1.17
 
+{% include plugins-spin-operator.md %}
+
 ## Add the plugin repository
 
 ```bash

--- a/guides/user/plugins/index.md
+++ b/guides/user/plugins/index.md
@@ -10,7 +10,7 @@ redirect_from:
 
 {% include toc %}
 
->Note: This guide is for plugins that run in Spinnaker 1.20.6 and 1.21+
+>Note: This guide is for plugins that run in Spinnaker 1.20.6 and 1.21+.
 
 ## Overview of Spinnaker plugins
 
@@ -42,6 +42,7 @@ Spinnaker environment:
 * Spinnaker v1.20.6, v1.21+
 * Halyard v1.36 to deploy Spinnaker
 
+{% include plugins-spin-operator.md %}
 
 ## How to add a plugin to Spinnaker
 


### PR DESCRIPTION
Since the plugin docs focus on Halyard, add link to
open source Spinnaker Operator repo docs for people who are
using that product to install and manage Spinnaker.