### PR TITLE
docs(echo): fix incorrect task status

### DIFF
--- a/setup/features/notifications/index.md
+++ b/setup/features/notifications/index.md
@@ -365,7 +365,7 @@ Events have details, which will always be the same.
 
 The type of the event will outline where the event is coming from:
 
-* orca:[task type]:[status] - where task type is either 'pipeline', 'stage' or 'task' and status is 'starting', 'completed', 'failed'
+* orca:[task type]:[status] - where task type is either 'pipeline', 'stage' or 'task' and status is 'starting', 'complete', 'failed'
 * build - from igor Jenkins events
 * docker - from igor Docker events
 * git - from git web triggers


### PR DESCRIPTION
Spinnaker 1.22.2
I think correct orca task's status is complete
Example 
```json
"details":{
  "source":"orca",
  "type":"orca:task:complete",
  "created":"1618923431949",
  "application":"test"
}
```
Here's some example from orca code: [1.22.2](https://github.com/spinnaker/echo/blob/f233237c78f52becaff19d202e2a6ed9137f3a07/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/TelemetryEventListener.java#L45), [master](https://github.com/spinnaker/echo/blob/c5e4ec2a0130744eb3995c744fe5e6dfe3c60587/echo-telemetry/src/main/java/com/netflix/spinnaker/echo/telemetry/TelemetryEventListener.java#L43)