### PR TITLE
docs(orca) mention bug with preconfigured webhooks

### DIFF
--- a/guides/operator/custom-webhook-stages/index.md
+++ b/guides/operator/custom-webhook-stages/index.md
@@ -27,7 +27,7 @@ Custom webhook stages support a variety of options, most of which are available 
 
 * `enabled` - whether the stage will appear in the UI
 * `label` - the human readable name of the stage
-* `description` - a human readable description of what the stage is used for
+* `description` - a human readable description of what the stage is used. *manadatory for some spinnaker versions*
 * `type` - a _unique_ key used to identifty the stage type within a pipeline
 * `url` - the url for the webhook
 * `customHeaders` - any headers needed for your webhook's http request. ex. API tokens.
@@ -139,3 +139,5 @@ parameters:
     name: description
     type: string
 ```
+### Troubleshooting
+ * *nothing in stage dropdown*. If after adding webhook you see nothing in stage dropdown check that you added description to preconfigured webhook.

--- a/guides/operator/custom-webhook-stages/index.md
+++ b/guides/operator/custom-webhook-stages/index.md
@@ -140,4 +140,4 @@ parameters:
     type: string
 ```
 ### Troubleshooting
- * *nothing in stage dropdown*. If after adding webhook you see nothing in stage dropdown check that you added description to preconfigured webhook.
+ * *stages do not apprear in deck*. If after adding webhook you see nothing in stage dropdown of pipeline configuration view check that you added description to preconfigured webhook.


### PR DESCRIPTION
Deck tried to .toLowerCase on undefined description. Then stage dropdown in pipeline configuration is empty. It is confusing for devs especially without js experience