### PR TITLE
Document account variable and Minio endpoint warning

### DIFF
--- a/setup/install/providers/kubernetes-v2/index.md
+++ b/setup/install/providers/kubernetes-v2/index.md
@@ -61,7 +61,7 @@ CONTEXT=$(kubectl config current-context)
 # This service account uses the ClusterAdmin role -- this is not necessary, 
 # more restrictive roles can by applied.
 kubectl apply --context $CONTEXT \
-    -f https://www.spinnaker.io/downloads/kubernetes/service-account.yml
+    -f https://spinnaker.io/downloads/kubernetes/service-account.yml
 
 TOKEN=$(kubectl get secret --context $CONTEXT \
    $(kubectl get serviceaccount spinnaker-service-account \
@@ -206,8 +206,8 @@ Then add the account:
 
 ```bash
 CONTEXT=$(kubectl config current-context)
-
-hal config provider kubernetes account add my-k8s-account \
+ACCOUNT="my-k8s-account"
+hal config provider kubernetes account add $ACCOUNT \
     --context $CONTEXT
 ```
 

--- a/setup/install/storage/minio.md
+++ b/setup/install/storage/minio.md
@@ -69,7 +69,9 @@ hal config storage edit --type s3
 ```
 
 ## Notes
-> :warning: Unless you've configured Minio to [support virtual-host-style requests](https://docs.min.io/docs/minio-server-configuration-guide.html#Domain), you need to enable the path-style access mode: `hal config storage s3 edit --path-style-access true`. Otherwise, Front50 will fail with `java.net.UnknownHostException: $BUCKET_NAME.localhost` exceptions.
+
+> :warning: Unless you've configured Minio to [support virtual-host-style requests](https://docs.min.io/docs/minio-server-configuration-guide.html#Domain), you need to enable the path-style access mode: `hal config storage s3 edit --path-style-access true`. Otherwise, Front50 will fail with `java.net.UnknownHostException: $BUCKET_NAME.localhost` exceptions.  
+> :warning: If you use Distributed installation and Front50 is in the crash loop, please set the endpoint as a Minio address instead of localhost.
 
 ## Next steps
 


### PR DESCRIPTION
$ACCOUNT variable used in [page enviroment](https://spinnaker.io/setup/install/environment/) but this variable is not set in kubernetes-v2 page.

In distributed installation storage endpoint is will be Minio remote IP or host instead of localhost otherwise Front50 is in the crash loop.