### PR TITLE
docs(stats): Fix halyard command to enable/disable telemetry

### DIFF
--- a/community/stats/index.md
+++ b/community/stats/index.md
@@ -44,14 +44,14 @@ The above payload is sent to `https://stats.spinnaker.io/log` upon the completio
 For release 1.18.x, telemetry is opt-in, as we test and scale the system and fine-tune the dashboards. Spinnaker administrators can help by turning **on** data collection by executing
 
 ```
-hal config telemetry enable
+hal config stats enable
 ```
 and redeploying.
 
 As of 1.19.0+, telemetry will be enabled by default. Spinnaker administrators can turn **off** data collection by executing
 
 ```
-hal config telemetry disable
+hal config stats disable
 ```
 and redeploying.
 


### PR DESCRIPTION
It seems that `hal config telemetry` has been renamed to `hal config stats`.

`hal config telemetry` does not work, as reported here: https://github.com/spinnaker/spinnaker/issues/6419

What's also a bit odd is that the stats page looks broken on my end: https://spinnaker.io/community/stats/

![image](https://user-images.githubusercontent.com/1234006/122950445-bd48c380-d37c-11eb-964b-4b0deafbc7b7.png)
